### PR TITLE
Add --no-lwp argument to cpanm when fetching from github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - cpanm --quiet --notest Test::Class
   - cpanm --quiet --notest Test::Exception
   - cpanm --quiet --notest Test::Perl::Critic
-  - cpanm --quiet --notest https://github.com/wtsi-npg/perl-dnap-utilities/releases/download/${DNAP_UTILITIES_VERSION}/WTSI-DNAP-Utilities-${DNAP_UTILITIES_VERSION}.tar.gz
+  - cpanm --no-lwp --notest https://github.com/wtsi-npg/perl-dnap-utilities/releases/download/${DNAP_UTILITIES_VERSION}/WTSI-DNAP-Utilities-${DNAP_UTILITIES_VERSION}.tar.gz
   - cd $TRAVIS_BUILD_DIR
 
 before_script:


### PR DESCRIPTION
This fixes the failed downloads of wtsi-npg dependency release tarballs.