### PR TITLE
Return AVUs when reading data objects.

### DIFF
--- a/lib/WTSI/NPG/Accountable.pm
+++ b/lib/WTSI/NPG/Accountable.pm
@@ -109,7 +109,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013-2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2014 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/Annotatable.pm
+++ b/lib/WTSI/NPG/Annotatable.pm
@@ -33,7 +33,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/Annotation.pm
+++ b/lib/WTSI/NPG/Annotation.pm
@@ -62,7 +62,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS.pm
+++ b/lib/WTSI/NPG/iRODS.pm
@@ -1836,7 +1836,8 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013-2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2014, 2015 Genome Research Limited. All Rights
+Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS.pm
+++ b/lib/WTSI/NPG/iRODS.pm
@@ -185,7 +185,7 @@ has 'obj_reader' =>
      my ($self) = @_;
 
      return WTSI::NPG::iRODS::DataObjectReader->new
-       (arguments   => ['--unbuffered'],
+       (arguments   => ['--unbuffered', '--avu'],
         environment => $self->environment,
         logger      => $self->logger,
         max_size    => $MAX_JSON_DATA_GET_SIZE)->start;

--- a/lib/WTSI/NPG/iRODS/ACLModifier.pm
+++ b/lib/WTSI/NPG/iRODS/ACLModifier.pm
@@ -99,7 +99,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS/Collection.pm
+++ b/lib/WTSI/NPG/iRODS/Collection.pm
@@ -313,7 +313,8 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013-2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2014, 2015 Genome Research Limited. All Rights
+Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS/Communicator.pm
+++ b/lib/WTSI/NPG/iRODS/Communicator.pm
@@ -101,7 +101,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS/DataObject.pm
+++ b/lib/WTSI/NPG/iRODS/DataObject.pm
@@ -349,7 +349,8 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013-2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2014, 2015 Genome Research Limited. All Rights
+Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS/DataObjectReader.pm
+++ b/lib/WTSI/NPG/iRODS/DataObjectReader.pm
@@ -82,7 +82,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS/GroupAdmin.pm
+++ b/lib/WTSI/NPG/iRODS/GroupAdmin.pm
@@ -255,7 +255,7 @@ David K. Jackson <david.jackson@sanger.ac.uk>
 
 =head2 LICENSE AND COPYRIGHT
 
-Copyright (c) 2013-2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2014 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS/Lister.pm
+++ b/lib/WTSI/NPG/iRODS/Lister.pm
@@ -264,7 +264,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013-2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2014 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS/MetaLister.pm
+++ b/lib/WTSI/NPG/iRODS/MetaLister.pm
@@ -96,7 +96,8 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013-2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2014, 2015 Genome Research Limited. All Rights
+Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS/MetaModifier.pm
+++ b/lib/WTSI/NPG/iRODS/MetaModifier.pm
@@ -107,7 +107,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013-2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2014 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS/MetaSearcher.pm
+++ b/lib/WTSI/NPG/iRODS/MetaSearcher.pm
@@ -70,3 +70,33 @@ __PACKAGE__->meta->make_immutable;
 no Moose;
 
 1;
+
+__END__
+
+=head1 NAME
+
+WTSI::NPG::iRODS::MetaSearcher
+
+=head1 DESCRIPTION
+
+A client that searches iRODS metadata.
+
+=head1 AUTHOR
+
+Keith James <kdj@sanger.ac.uk>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2014 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/lib/WTSI/NPG/iRODS/Path.pm
+++ b/lib/WTSI/NPG/iRODS/Path.pm
@@ -402,7 +402,8 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013-2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2014, 2015 Genome Research Limited. All Rights
+Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS/Storable.pm
+++ b/lib/WTSI/NPG/iRODS/Storable.pm
@@ -80,7 +80,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/iRODS/Version.pm
+++ b/lib/WTSI/NPG/iRODS/Version.pm
@@ -9,3 +9,36 @@ use vars qw($VERSION);
 $VERSION = '';
 
 1;
+
+__END__
+
+=head1 NAME
+
+WTSI::NPG::iRODS::Version
+
+Package version.
+
+=head1 DESCRIPTION
+
+Represents the package version. Populated at build time using git
+--describe.
+
+=head1 AUTHOR
+
+Keith James <kdj@sanger.ac.uk>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2014 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut


### PR DESCRIPTION
This ensures that there is sufficient metadata to identify the file contents when working with a
batch of data objects returned from another query.