### PR TITLE
Argument check fix, performance fix

### DIFF
--- a/lib/WTSI/NPG/iRODS.pm
+++ b/lib/WTSI/NPG/iRODS.pm
@@ -79,7 +79,35 @@ has 'lister' =>
      my ($self) = @_;
 
      return WTSI::NPG::iRODS::Lister->new
-       (arguments   => ['--unbuffered', '--acl', '--contents', '--checksum'],
+       (arguments   => ['--unbuffered', '--contents', '--checksum'],
+        environment => $self->environment,
+        logger      => $self->logger)->start;
+   });
+
+has 'acl_lister' =>
+  (is       => 'ro',
+   isa      => 'WTSI::NPG::iRODS::Lister',
+   required => 1,
+   lazy     => 1,
+   default  => sub {
+     my ($self) = @_;
+
+     return WTSI::NPG::iRODS::Lister->new
+       (arguments   => ['--unbuffered', '--acl', '--contents'],
+        environment => $self->environment,
+        logger      => $self->logger)->start;
+   });
+
+has 'content_lister' =>
+  (is       => 'ro',
+   isa      => 'WTSI::NPG::iRODS::Lister',
+   required => 1,
+   lazy     => 1,
+   default  => sub {
+     my ($self) = @_;
+
+     return WTSI::NPG::iRODS::Lister->new
+       (arguments   => ['--unbuffered', '--contents', '--checksum'],
         environment => $self->environment,
         logger      => $self->logger)->start;
    });
@@ -569,7 +597,7 @@ sub list_collection {
   my $recursively = $recurse ? 'recursively' : q{};
   $self->debug("Listing collection '$collection' $recursively");
 
-  return $self->lister->list_collection($collection, $recurse);
+  return $self->content_lister->list_collection($collection, $recurse);
 }
 
 =head2 add_collection
@@ -764,7 +792,7 @@ sub get_collection_permissions {
 
   $collection = $self->_ensure_collection_path($collection);
 
-  return $self->lister->get_collection_acl($collection);
+  return $self->acl_lister->get_collection_acl($collection);
 }
 
 sub set_collection_permissions {
@@ -1427,7 +1455,7 @@ sub get_object_permissions {
 
   $object = $self->_ensure_object_path($object);
 
-  return $self->lister->get_object_acl($object);
+  return $self->acl_lister->get_object_acl($object);
 }
 
 sub set_object_permissions {

--- a/lib/WTSI/NPG/iRODS/Collection.pm
+++ b/lib/WTSI/NPG/iRODS/Collection.pm
@@ -170,8 +170,7 @@ sub get_contents {
 
    my $object_checksums;
    if ($checksums) {
-     $object_checksums = $self->irods->collection_checksums
-       ($self->str, $recurse);
+     $object_checksums = $self->irods->collection_checksums($path, $recurse);
    }
 
    my @objects;
@@ -186,7 +185,7 @@ sub get_contents {
        }
        else {
          $self->logwarn("Failed to find a checksum for '$obj' when getting ",
-                        "the contents of '", $self->str, q{'});
+                        "the contents of '$path'");
        }
      }
 

--- a/lib/WTSI/NPG/iRODS/Lister.pm
+++ b/lib/WTSI/NPG/iRODS/Lister.pm
@@ -165,12 +165,32 @@ sub list_collection {
   if ($obj_specs and $coll_specs) {
     my @data_objects = map { $self->path_spec_str($_) } @$obj_specs;
     my @collections  = map { $self->path_spec_str($_) } @$coll_specs;
-    my %checksums    = map { $self->path_spec_str($_) =>
-                             $self->path_spec_checksum($_) } @$obj_specs;
-    @paths = (\@data_objects, \@collections, \%checksums);
+    @paths = (\@data_objects, \@collections);
   }
 
   return @paths;
+}
+
+sub list_collection_checksums {
+  my ($self, $collection, $recur) = @_;
+
+  my $obj_specs;
+  my $coll_specs; # Ignore
+
+  if ($recur) {
+    ($obj_specs, $coll_specs) = $self->_list_collection_recur($collection);
+  }
+  else {
+    ($obj_specs, $coll_specs) = $self->_list_collection($collection);
+  }
+
+  my %checksums;
+  if ($obj_specs) {
+    %checksums = map { $self->path_spec_str($_) =>
+                       $self->path_spec_checksum($_) } @$obj_specs;
+  }
+
+  return \%checksums;
 }
 
 =head2 get_object_acl

--- a/lib/WTSI/NPG/iRODS/MetaSearcher.pm
+++ b/lib/WTSI/NPG/iRODS/MetaSearcher.pm
@@ -1,6 +1,7 @@
 
 package WTSI::NPG::iRODS::MetaSearcher;
 
+use Data::Dump qw(dump);
 use File::Spec;
 use Moose;
 
@@ -29,15 +30,22 @@ sub search {
 
   my $i = 0;
   foreach my $avu (@avus) {
+    ##no critic (CodeLayout::ProhibitParensWithBuiltins)
     unless (ref $avu eq 'HASH') {
-      $self->logconfess("A query AVU must be a HashRef: AVU #$i was not");
+      $self->logconfess("A query AVU must be a HashRef: AVU #$i was not: ",
+                        dump($avu));
     }
-    unless ($avu->{attribute}) {
-      $self->logconfess("A query AVU must have an attribute: AVU #$i did not");
+
+    # Zero length keys and values are rejected by iRODS
+    unless (length $avu->{attribute}) {
+      $self->logconfess("A query AVU must have an attribute: AVU #$i did not:",
+                        dump($avu));
     }
-    unless ($avu->{value}) {
-      $self->logconfess("A query AVU must have a value: AVU #$i did not");
+    unless (length $avu->{value}) {
+      $self->logconfess("A query AVU must have a value: AVU #$i did not:",
+                        dump($avu));
     }
+    ##use critic
     $i++;
   }
 

--- a/lib/WTSI/NPG/iRODS/MetaSearcher.pm
+++ b/lib/WTSI/NPG/iRODS/MetaSearcher.pm
@@ -1,7 +1,6 @@
 
 package WTSI::NPG::iRODS::MetaSearcher;
 
-use Data::Dump qw(dump);
 use File::Spec;
 use Moose;
 
@@ -30,22 +29,24 @@ sub search {
 
   my $i = 0;
   foreach my $avu (@avus) {
-    ##no critic (CodeLayout::ProhibitParensWithBuiltins)
     unless (ref $avu eq 'HASH') {
-      $self->logconfess("A query AVU must be a HashRef: AVU #$i was not: ",
-                        dump($avu));
+      $self->logconfess("A query AVU must be a HashRef: AVU #$i was not");
     }
+
+    my $astr = defined $avu->{attribute} ? $avu->{attribute} : 'undef';
+    my $vstr = defined $avu->{value}     ? $avu->{value}     : 'undef';
+    my $ustr = defined $avu->{units}     ? $avu->{units}     : 'undef';
 
     # Zero length keys and values are rejected by iRODS
     unless (length $avu->{attribute}) {
-      $self->logconfess("A query AVU must have an attribute: AVU #$i did not:",
-                        dump($avu));
+      $self->logconfess("A query AVU must have an attribute: AVU #$i did not: ",
+                        "{$astr, $vstr, $ustr}");
     }
     unless (length $avu->{value}) {
-      $self->logconfess("A query AVU must have a value: AVU #$i did not:",
-                        dump($avu));
+      $self->logconfess("A query AVU must have a value: AVU #$i did not: ",
+                        "{$astr, $vstr, $ustr}");
     }
-    ##use critic
+
     $i++;
   }
 

--- a/t/lib/WTSI/NPG/iRODSTest.pm
+++ b/t/lib/WTSI/NPG/iRODSTest.pm
@@ -14,7 +14,7 @@ use Try::Tiny;
 use Unicode::Collate;
 
 use base qw(Test::Class);
-use Test::More tests => 210;
+use Test::More tests => 218;
 use Test::Exception;
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
@@ -937,6 +937,32 @@ sub make_object_avu_history : Test(4) {
   dies_ok {
     $irods->make_object_avu_history($lorem_object, 'no_such_attribute');
   }
+}
+
+sub add_remove_perl_false_avu : Test(8) {
+  my $irods = WTSI::NPG::iRODS->new(strict_baton_version => 0);
+
+  my $lorem_object = "$irods_tmp_coll/irods/lorem.txt";
+  ok($irods->add_object_avu($lorem_object, 0, 0, 0),
+     'Add 0 int object AVU');
+  ok($irods->remove_object_avu($lorem_object, 0, 0, 0),
+     'Remove 0 int object AVU');
+
+  ok($irods->add_object_avu($lorem_object, '0', '0', '0'),
+     'Add 0 string object AVU');
+  ok($irods->remove_object_avu($lorem_object, '0', '0', '0'),
+     'Remove 0 string object AVU');
+
+  my $test_coll = $irods_tmp_coll;
+  ok($irods->add_collection_avu($test_coll, 0, 0, 0),
+     'Add 0 int collection AVU');
+  ok($irods->remove_collection_avu($test_coll, 0, 0, 0),
+     'Remove 0 int collection AVU');
+
+  ok($irods->add_collection_avu($test_coll, '0', '0', '0'),
+     'Add 0 string collection AVU');
+  ok($irods->remove_collection_avu($test_coll, '0', '0', '0'),
+     'Remove 0 string collection AVU');
 }
 
 sub find_objects_by_meta : Test(7) {


### PR DESCRIPTION
This commit fixes two bugs:

It was impossible to search with metadata AVUs where any part was Perl
zero (int or string). This was caused by overzealous argument checking.

Using a single lister for paths, ACLs, checksums and collection
contents caused a performance bottleneck due to unnecessary ACL
lookups. Separate listers have been added for ACLs and collection
contents.