### PR TITLE
Avoid creating unnecessary {units => undef} pairs in AVUs

### DIFF
--- a/lib/WTSI/NPG/iRODS/Path.pm
+++ b/lib/WTSI/NPG/iRODS/Path.pm
@@ -79,19 +79,6 @@ sub BUILD {
   return $self;
 }
 
-around 'metadata' => sub {
-   my ($orig, $self, @args) = @_;
-
-   my @sorted = sort {
-     $a->{attribute} cmp $b->{attribute}                    ||
-     $a->{value}     cmp $b->{value}                        ||
-     (( defined $a->{units} && !defined $b->{units}) && -1) ||
-     ((!defined $a->{units} &&  defined $b->{units}) &&  1) ||
-     $a->{units}     cmp $b->{units} } @{$self->$orig(@args)};
-
-   return \@sorted;
-};
-
 =head2 get_avu
 
   Arg [1]    : attribute
@@ -366,9 +353,7 @@ sub _update_multivalue_avus {
   $self->debug("Updating all '$attribute' AVUs on '", $self->str, q{'});
 
   my @old_avus = $self->find_in_metadata($attribute);
-  my @new_avus = map { {attribute => $attribute,
-                        value     => $_,
-                        units     => $units} } @values;
+  my @new_avus = map { $self->make_avu($attribute, $_, $units) } @values;
 
   # Compare old AVUS to new; if any of the new ones are already
   # present, leave the old copy, otherwise remove the old AVU

--- a/lib/WTSI/NPG/iRODS/Utilities.pm
+++ b/lib/WTSI/NPG/iRODS/Utilities.pm
@@ -79,6 +79,7 @@ sub md5sum {
                  {attribute => $attribute,
                   value     => $value,
                   units     => $units}
+               The units key is absent if units are not defined.
   Returntype : HashRef
 
 =cut
@@ -96,9 +97,13 @@ sub make_avu {
   $value eq q{} and
     $self->logconfess('A non-empty value argument is required');
 
-  return {attribute => $attribute,
-          value     => $value,
-          units     => $units};
+  my $avu = {attribute => $attribute,
+             value     => $value};
+  if (defined $units) {
+    $avu->{units} = $units;
+  }
+
+  return $avu;
 }
 
 =head2 avus_equal
@@ -123,7 +128,7 @@ sub avus_equal {
   defined $avu_y or $self->logconfess('A defined avu_y argument is required');
 
   ref $avu_x eq 'HASH' or
-    $self->logconfess('The avu_x argument mus be a HashRef');
+    $self->logconfess('The avu_x argument must be a HashRef');
   ref $avu_y eq 'HASH' or
     $self->logconfess('The avu_y argument mus be a HashRef');
 

--- a/t/lib/WTSI/NPG/iRODSTest.pm
+++ b/t/lib/WTSI/NPG/iRODSTest.pm
@@ -1213,7 +1213,7 @@ sub make_avu : Test(6) {
   my $avu1 = $irods->make_avu('a', 'b', 'c');
   is_deeply($avu1, $expected1, 'AVU with units') or diag explain $avu1;
 
-  my $expected2 = {attribute => 'a', value => 'b', units => undef};
+  my $expected2 = {attribute => 'a', value => 'b'};
   my $avu2 = $irods->make_avu('a', 'b');
   is_deeply($avu2, $expected2, 'AVU without units') or diag explain $avu2;
 


### PR DESCRIPTION
Removed the "around" method on metadata because the underlying WTSI::NPG::iRODS metadata fetch method now sorts the AVUs, making this redundant.

Avoid creating unnecessary {units => undef} pairs in AVUs. The convention is that if units are not present, we don't include the key.