### PR TITLE
Improvements to tests relating to iRODS groups

### DIFF
--- a/t/lib/WTSI/NPG/DriRODSTest.pm
+++ b/t/lib/WTSI/NPG/DriRODSTest.pm
@@ -8,11 +8,9 @@ use List::AllUtils qw(none);
 use Log::Log4perl;
 
 use base qw(Test::Class);
-use Test::More tests => 54;
+use Test::More;
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
-
-BEGIN { use_ok('WTSI::NPG::DriRODS'); }
 
 use WTSI::NPG::DriRODS;
 use WTSI::NPG::iRODS;
@@ -87,7 +85,7 @@ sub add_group : Test(3) {
   my $test_group = "test_group." . $PID;
 
  SKIP: {
-    if (not $have_admin_rights and $group_tests_enabled) {
+    if (not ($have_admin_rights and $group_tests_enabled)) {
       skip 'iRODS group tests were not enabled with admin rights', 3;
     }
 
@@ -103,7 +101,7 @@ sub remove_group : Test(3) {
   my $test_group = "ss_0";
 
  SKIP: {
-    if (not $have_admin_rights and $group_tests_enabled) {
+    if (not ($have_admin_rights and $group_tests_enabled)) {
       skip 'iRODS group tests were not enabled with admin rights', 3;
     }
 
@@ -263,7 +261,7 @@ sub add_object : Test(2) {
   ok(!$drirods->list_object($lorem_object), 'Data object not added');
 }
 
-sub replace_object : Test(3) {
+sub replace_object : Test(2) {
   my $drirods = WTSI::NPG::DriRODS->new(strict_baton_version => 0);
 
   my $tmp = File::Temp->new;

--- a/t/lib/WTSI/NPG/iRODS/CollectionTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/CollectionTest.pm
@@ -8,12 +8,10 @@ use List::AllUtils qw(all any none);
 use Log::Log4perl;
 
 use base qw(Test::Class);
-use Test::More tests => 53;
+use Test::More;
 use Test::Exception;
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
-
-BEGIN { use_ok('WTSI::NPG::iRODS::Collection'); }
 
 use WTSI::NPG::iRODS::Collection;
 

--- a/t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
@@ -8,12 +8,10 @@ use List::AllUtils qw(all any none);
 use Log::Log4perl;
 
 use base qw(Test::Class);
-use Test::More tests => 96;
+use Test::More;
 use Test::Exception;
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
-
-BEGIN { use_ok('WTSI::NPG::iRODS::DataObject'); }
 
 use WTSI::NPG::iRODS::DataObject;
 use WTSI::NPG::iRODS::Metadata qw($STUDY_ID);

--- a/t/lib/WTSI/NPG/iRODS/PerformanceTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/PerformanceTest.pm
@@ -8,7 +8,7 @@ use File::Temp qw(tempdir);
 use List::AllUtils qw(any);
 
 use base qw(Test::Class);
-use Test::More tests => 9;
+use Test::More;
 
 use WTSI::NPG::iRODS;
 

--- a/t/lib/WTSI/NPG/iRODSTest.pm
+++ b/t/lib/WTSI/NPG/iRODSTest.pm
@@ -13,13 +13,10 @@ use Try::Tiny;
 use Unicode::Collate;
 
 use base qw(Test::Class);
-use Test::More tests => 263;
-
+use Test::More;
 use Test::Exception;
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
-
-BEGIN { use_ok('WTSI::NPG::iRODS'); }
 
 use WTSI::NPG::iRODS;
 

--- a/t/lib/WTSI/NPG/iRODSTest.pm
+++ b/t/lib/WTSI/NPG/iRODSTest.pm
@@ -36,9 +36,11 @@ my $have_admin_rights =
 # Prefix for test iRODS data access groups
 my $group_prefix = 'ss_';
 # Groups to be added to the test iRODS
-my @irods_groups = map { $group_prefix . $_ } (10, 100);
+my @irods_groups = map { $group_prefix . $_ } (0, 10, 100);
 # Groups added to the test iRODS in fixture setup
 my @groups_added;
+# Enable group tests
+my $group_tests_enabled = 0;
 
 sub make_fixture : Test(setup) {
   my $irods = WTSI::NPG::iRODS->new(strict_baton_version => 0);
@@ -58,12 +60,21 @@ sub make_fixture : Test(setup) {
     }
   }
 
+  my $group_count = 0;
   foreach my $group (@irods_groups) {
-    if (not $irods->group_exists($group)) {
+    if ($irods->group_exists($group)) {
+      $group_count++;
+    }
+    else {
       if ($have_admin_rights) {
         push @groups_added, $irods->add_group($group);
+        $group_count++;
       }
     }
+  }
+
+  if ($group_count == scalar @irods_groups) {
+    $group_tests_enabled = 1;
   }
 }
 
@@ -289,8 +300,8 @@ sub get_object_groups : Test(7) {
    my $lorem_object = "$irods_tmp_coll/irods/lorem.txt";
 
  SKIP: {
-     if (not $irods->group_exists('ss_0')) {
-       skip "Skipping test requiring the test group ss_0", 6;
+     if (not $group_tests_enabled) {
+       skip 'iRODS test groups were not present', 6;
      }
 
      ok($irods->set_object_permissions('read', 'public', $lorem_object));
@@ -371,8 +382,8 @@ sub get_collection_groups : Test(7) {
   my $coll = "$irods_tmp_coll/irods";
 
  SKIP: {
-    if (not $irods->group_exists('ss_0')) {
-      skip "Skipping test requiring the test group ss_0", 6;
+    if (not $group_tests_enabled) {
+      skip 'iRODS test groups were not present', 6;
     }
 
     ok($irods->set_collection_permissions('read', 'public', $coll));
@@ -1319,6 +1330,5 @@ sub avus_equal : Test(9) {
                          {attribute => 'a', value => 'w'}),
      'AVs != on u');
 }
-
 
 1;


### PR DESCRIPTION
Only enable any group tests if all test groups are present.

Only try DriRODS group removal tests as an admin who can remove
groups.