### PR TITLE
Require explicit declaration of the test iRODS environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ before_script:
 script:
   - perl Build.PL
   - ./Build clean
+  - export WTSI_NPG_iRODS_Test_irodsEnvFile=$irodsEnvFile
   - ./Build test
 
 after_script:

--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+ - Require explicit declaration of the test iRODS environment rather than
+   using the user's default
 
 Release 2.0.1
 

--- a/t/drirods.t
+++ b/t/drirods.t
@@ -2,6 +2,15 @@
 use strict;
 use warnings;
 
-use WTSI::NPG::DriRODSTest;
+local $ENV{'irodsEnvFile'} = $ENV{'WTSI_NPG_iRODS_Test_irodsEnvFile'};
+BEGIN{
+  $ENV{'irodsEnvFile'} = $ENV{'WTSI_NPG_iRODS_Test_irodsEnvFile'};
+}BEGIN{
+  use WTSI::NPG::DriRODSTest;
+}
+
+if(not $ENV{'irodsEnvFile'}){
+  WTSI::NPG::DriRODSTest->SKIP_CLASS('No test iRODS enviroment found from environment variable "WTSI_NPG_iRODS_Test_irodsEnvFile"');
+}
 
 Test::Class->runtests;

--- a/t/irods.t
+++ b/t/irods.t
@@ -2,6 +2,15 @@
 use strict;
 use warnings;
 
-use WTSI::NPG::iRODSTest;
+local $ENV{'irodsEnvFile'} = $ENV{'WTSI_NPG_iRODS_Test_irodsEnvFile'};
+BEGIN{
+  $ENV{'irodsEnvFile'} = $ENV{'WTSI_NPG_iRODS_Test_irodsEnvFile'};
+}BEGIN{
+  use WTSI::NPG::iRODSTest;
+}
+
+if(not $ENV{'irodsEnvFile'}){
+  WTSI::NPG::iRODSTest->SKIP_CLASS('No test iRODS enviroment found from environment variable "WTSI_NPG_iRODS_Test_irodsEnvFile"');
+}
 
 Test::Class->runtests;

--- a/t/irods_collection_test.t
+++ b/t/irods_collection_test.t
@@ -4,4 +4,10 @@ use warnings;
 
 use WTSI::NPG::iRODS::CollectionTest;
 
+local $ENV{'irodsEnvFile'} = $ENV{'WTSI_NPG_iRODS_Test_irodsEnvFile'};
+if(not $ENV{'irodsEnvFile'}){
+  WTSI::NPG::iRODS::CollectionTest->SKIP_CLASS('No test iRODS enviroment found from environment variable "WTSI_NPG_iRODS_Test_irodsEnvFile"');
+}
+
+
 Test::Class->runtests;

--- a/t/irods_dataobject_test.t
+++ b/t/irods_dataobject_test.t
@@ -4,4 +4,9 @@ use warnings;
 
 use WTSI::NPG::iRODS::DataObjectTest;
 
+local $ENV{'irodsEnvFile'} = $ENV{'WTSI_NPG_iRODS_Test_irodsEnvFile'};
+if(not $ENV{'irodsEnvFile'}){
+  WTSI::NPG::iRODS::DataObjectTest->SKIP_CLASS('No test iRODS enviroment found from environment variable "WTSI_NPG_iRODS_Test_irodsEnvFile"');
+} 
+
 Test::Class->runtests;

--- a/t/lib/WTSI/NPG/DriRODSTest.pm
+++ b/t/lib/WTSI/NPG/DriRODSTest.pm
@@ -12,6 +12,8 @@ use Test::More;
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
 
+sub use_class : Test(0) { use_ok('WTSI::NPG::DriRODS'); }
+
 use WTSI::NPG::DriRODS;
 use WTSI::NPG::iRODS;
 use WTSI::NPG::iRODS::DataObject;

--- a/t/lib/WTSI/NPG/iRODS/CollectionTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/CollectionTest.pm
@@ -13,6 +13,8 @@ use Test::Exception;
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
 
+sub use_class : Test(1) { use_ok('WTSI::NPG::iRODS::Collection'); }
+
 use WTSI::NPG::iRODS::Collection;
 
 my $fixture_counter = 0;

--- a/t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
@@ -13,6 +13,8 @@ use Test::Exception;
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
 
+sub use_class : Test(1) { use_ok('WTSI::NPG::iRODS::DataObject'); }
+
 use WTSI::NPG::iRODS::DataObject;
 use WTSI::NPG::iRODS::Metadata qw($STUDY_ID);
 

--- a/t/lib/WTSI/NPG/iRODSTest.pm
+++ b/t/lib/WTSI/NPG/iRODSTest.pm
@@ -18,6 +18,8 @@ use Test::Exception;
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
 
+sub use_class : Test(1) { use_ok('WTSI::NPG::iRODS'); }
+
 use WTSI::NPG::iRODS;
 
 my $pid = $PID;

--- a/t/performance.t
+++ b/t/performance.t
@@ -4,4 +4,9 @@ use warnings;
 
 use WTSI::NPG::iRODS::PerformanceTest;
 
+local $ENV{'irodsEnvFile'} = $ENV{'WTSI_NPG_iRODS_Test_irodsEnvFile'};
+if(not $ENV{'irodsEnvFile'}){
+  WTSI::NPG::iRODS::PerformanceTest->SKIP_CLASS('No test iRODS enviroment found from environment variable "WTSI_NPG_iRODS_Test_irodsEnvFile"');
+}
+
 Test::Class->runtests;


### PR DESCRIPTION
rather than using the user's default. Fixes #42 ? Base test class may be a better way than this....
