### PR TITLE
Added test base class to handle setting irodsEnvFile environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_script:
 script:
   - perl Build.PL
   - ./Build clean
-  - WTSI_NPG_iRODS_Test_irodsEnvFile=${irodsEnvFile} ./Build test
+  - TEST_AUTHOR=1 WTSI_NPG_iRODS_Test_irodsEnvFile=${irodsEnvFile} ./Build test
 
 after_script:
   - $TRAVIS_BUILD_DIR/irodscontrol istop

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_script:
 script:
   - perl Build.PL
   - ./Build clean
-  - ./Build test
+  - WTSI_NPG_iRODS_Test_irodsEnvFile=${irodsEnvFile} ./Build test
 
 after_script:
   - $TRAVIS_BUILD_DIR/irodscontrol istop

--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+ - Tests now require explict declaration of the iRODS test environment.
 
 Release 2.0.1
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -61,6 +61,7 @@ t/lib/WTSI/NPG/DriRODSTest.pm
 t/lib/WTSI/NPG/iRODS/CollectionTest.pm
 t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
 t/lib/WTSI/NPG/iRODS/PerformanceTest.pm
+t/lib/WTSI/NPG/iRODS/Test.pm
 t/lib/WTSI/NPG/iRODSTest.pm
 t/performance.t
 t/perlcriticrc

--- a/t/drirods.t
+++ b/t/drirods.t
@@ -4,4 +4,4 @@ use warnings;
 
 use WTSI::NPG::DriRODSTest;
 
-Test::Class->runtests;
+WTSI::NPG::DriRODSTest->runtests;

--- a/t/irods.t
+++ b/t/irods.t
@@ -4,4 +4,4 @@ use warnings;
 
 use WTSI::NPG::iRODSTest;
 
-Test::Class->runtests;
+WTSI::NPG::iRODSTest->runtests;

--- a/t/irods_collection_test.t
+++ b/t/irods_collection_test.t
@@ -4,4 +4,4 @@ use warnings;
 
 use WTSI::NPG::iRODS::CollectionTest;
 
-Test::Class->runtests;
+WTSI::NPG::iRODS::CollectionTest->runtests;

--- a/t/irods_dataobject_test.t
+++ b/t/irods_dataobject_test.t
@@ -4,4 +4,4 @@ use warnings;
 
 use WTSI::NPG::iRODS::DataObjectTest;
 
-Test::Class->runtests;
+WTSI::NPG::iRODS::DataObjectTest->runtests;

--- a/t/lib/WTSI/NPG/DriRODSTest.pm
+++ b/t/lib/WTSI/NPG/DriRODSTest.pm
@@ -7,7 +7,7 @@ use File::Temp;
 use List::AllUtils qw(none);
 use Log::Log4perl;
 
-use base qw(Test::Class);
+use base qw(WTSI::NPG::iRODS::Test);
 use Test::More;
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
@@ -39,7 +39,7 @@ my $group_tests_enabled = 0;
 sub make_fixture : Test(setup) {
   my $irods = WTSI::NPG::iRODS->new(strict_baton_version => 0);
 
-  $irods_tmp_coll = $irods->add_collection("iRODSTest.$pid.$fixture_counter");
+  $irods_tmp_coll = $irods->add_collection("DriRODSTest.$pid.$fixture_counter");
   $fixture_counter++;
   $irods->put_collection($data_path, $irods_tmp_coll);
 

--- a/t/lib/WTSI/NPG/iRODS/CollectionTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/CollectionTest.pm
@@ -7,7 +7,7 @@ use File::Spec;
 use List::AllUtils qw(all any none);
 use Log::Log4perl;
 
-use base qw(Test::Class);
+use base qw(WTSI::NPG::iRODS::Test);
 use Test::More;
 use Test::Exception;
 

--- a/t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
@@ -7,7 +7,7 @@ use File::Spec;
 use List::AllUtils qw(all any none);
 use Log::Log4perl;
 
-use base qw(Test::Class);
+use base qw(WTSI::NPG::iRODS::Test);
 use Test::More;
 use Test::Exception;
 

--- a/t/lib/WTSI/NPG/iRODS/PerformanceTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/PerformanceTest.pm
@@ -7,7 +7,7 @@ use English qw(-no_match_vars);
 use File::Temp qw(tempdir);
 use List::AllUtils qw(any);
 
-use base qw(Test::Class);
+use base qw(WTSI::NPG::iRODS::Test);
 use Test::More;
 
 use WTSI::NPG::iRODS;

--- a/t/lib/WTSI/NPG/iRODS/Test.pm
+++ b/t/lib/WTSI/NPG/iRODS/Test.pm
@@ -1,0 +1,24 @@
+package WTSI::NPG::iRODS::Test;
+
+use strict;
+use warnings;
+
+use base qw(Test::Class);
+use Test::More;
+
+sub runtests {
+  my ($self) = @_;
+
+  my $env_file = $ENV{'WTSI_NPG_iRODS_Test_irodsEnvFile'};
+
+  if ($env_file) {
+    local $ENV{'irodsEnvFile'} = $env_file;
+    return $self->SUPER::runtests;
+  }
+  else {
+    die 'Environment variable WTSI_NPG_iRODS_Test_irodsEnvFile was not set';
+  }
+}
+
+1;
+

--- a/t/lib/WTSI/NPG/iRODS/Test.pm
+++ b/t/lib/WTSI/NPG/iRODS/Test.pm
@@ -6,19 +6,25 @@ use warnings;
 use base qw(Test::Class);
 use Test::More;
 
+# Run full tests (requiring a test iRODS server) only if TEST_AUTHOR
+# is true. If full tests are run, require that irodsEnvFile be set.
 sub runtests {
   my ($self) = @_;
 
-  my $env_file = $ENV{'WTSI_NPG_iRODS_Test_irodsEnvFile'};
+  my $env_file = $ENV{'WTSI_NPG_iRODS_Test_irodsEnvFile'} || q{};
+  if (not $env_file) {
+    if ($ENV{TEST_AUTHOR}) {
+      die 'Environment variable WTSI_NPG_iRODS_Test_irodsEnvFile was not set';
+    }
+    else {
+      $self->SKIP_CLASS('TEST_AUTHOR environment variable is false');
+    }
+  }
 
-  if ($env_file) {
+  {
     local $ENV{'irodsEnvFile'} = $env_file;
     return $self->SUPER::runtests;
-  }
-  else {
-    die 'Environment variable WTSI_NPG_iRODS_Test_irodsEnvFile was not set';
   }
 }
 
 1;
-

--- a/t/lib/WTSI/NPG/iRODSTest.pm
+++ b/t/lib/WTSI/NPG/iRODSTest.pm
@@ -12,7 +12,7 @@ use Log::Log4perl;
 use Try::Tiny;
 use Unicode::Collate;
 
-use base qw(Test::Class);
+use base qw(WTSI::NPG::iRODS::Test);
 use Test::More;
 use Test::Exception;
 

--- a/t/performance.t
+++ b/t/performance.t
@@ -4,4 +4,4 @@ use warnings;
 
 use WTSI::NPG::iRODS::PerformanceTest;
 
-Test::Class->runtests;
+WTSI::NPG::iRODS::PerformanceTest->runtests;


### PR DESCRIPTION
Added test base class to handle setting irodsEnvFile environment variable.

Removed Test::More plan test counts because they can
calculated. Removed use_ok tests in BEGIN blocks because they cannot
be counted automatically and 'use' failures are evident anyway when
they occur.