### PR TITLE
Support baton 0.16.2

### DIFF
--- a/lib/WTSI/NPG/iRODS.pm
+++ b/lib/WTSI/NPG/iRODS.pm
@@ -27,7 +27,7 @@ with 'WTSI::DNAP::Utilities::Loggable', 'WTSI::NPG::iRODS::Utilities';
 
 our $VERSION = '';
 
-our $MAX_BATON_VERSION = '0.16.1';
+our $MAX_BATON_VERSION = '0.16.2';
 our $MIN_BATON_VERSION = '0.16.0';
 
 our $IADMIN      = 'iadmin';

--- a/t/lib/WTSI/NPG/iRODSTest.pm
+++ b/t/lib/WTSI/NPG/iRODSTest.pm
@@ -97,11 +97,11 @@ sub require : Test(1) {
   require_ok('WTSI::NPG::iRODS');
 }
 
-sub compatible_baton_versions : Test(2) {
+sub compatible_baton_versions : Test(3) {
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
                                     strict_baton_version => 0);
 
-  my @compatible_versions = qw(0.16.0 0.16.1);
+  my @compatible_versions = qw(0.16.0 0.16.1 0.16.2);
 
   foreach my $version (@compatible_versions) {
     ok($irods->match_baton_version($version),


### PR DESCRIPTION
baton 0.16.2 is a release that fixes a bug wtsi-npg/baton/issues/140 for HGI