### PR TITLE
Permit user#zone syntax for users and groups

### DIFF
--- a/lib/WTSI/NPG/DriRODS.pm
+++ b/lib/WTSI/NPG/DriRODS.pm
@@ -58,7 +58,7 @@ stubs.
 
 =head1 DESCRIPTION
 
-This calss enables dry-run operations to be carried on iRODS out more
+This class enables dry-run operations to be carried on iRODS out more
 easily. Simply replace your iRODS handle with an instance of this
 class and all the method calls that would change data and/or metadata
 will be logged at INFO level, along with their arguments.

--- a/lib/WTSI/NPG/iRODS/Collection.pm
+++ b/lib/WTSI/NPG/iRODS/Collection.pm
@@ -232,7 +232,8 @@ sub get_permissions {
                $WTSI::NPG::iRODS::WRITE_PERMISSION,
                $WTSI::NPG::iRODS::OWN_PERMISSION or
                $WTSI::NPG::iRODS::NULL_PERMISSION.
-  Arg [2]    : Array of owners (users and /or groups).
+  Arg [2]    : Array of owners (users and/or groups). These may be of the
+               form <user> or <user>#<zone>.
 
   Example    : $coll->set_permissions('read', 'user1', 'group1')
   Description: Set access permissions on the collection. Return self.

--- a/lib/WTSI/NPG/iRODS/DataObject.pm
+++ b/lib/WTSI/NPG/iRODS/DataObject.pm
@@ -272,7 +272,8 @@ sub get_permissions {
                $WTSI::NPG::iRODS::WRITE_PERMISSION,
                $WTSI::NPG::iRODS::OWN_PERMISSION or
                $WTSI::NPG::iRODS::NULL_PERMISSION.
-  Arg [2]    : Array of owners (users and /or groups).
+  Arg [2]    : Array of owners (users and /or groups). These may be of the
+               form <user> or <user>#<zone>.
 
   Example    : $obj->set_permissions($WTSI::NPG::iRODS::READ_PERMISSION,
                                      'user1', 'group1')

--- a/t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
@@ -498,7 +498,7 @@ sub get_permissions : Test(1) {
   ok($perms, 'Permissions obtained');
 }
 
-sub set_permissions : Test(7) {
+sub set_permissions : Test(9) {
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
                                     strict_baton_version => 0);
   my $obj_path = "$irods_tmp_coll/irods_path_test/test_dir/test_file.txt";
@@ -511,7 +511,8 @@ sub set_permissions : Test(7) {
   ok($r0, 'No public read access');
 
   # Set public read
-  ok($obj->set_permissions('read', 'public'));
+  ok($obj->set_permissions('read', 'public'),
+     'Set permission using an implicit zone');
 
   my $r1 = any { exists $_->{owner} && $_->{owner} eq 'public' &&
                  exists $_->{level} && $_->{level} eq 'read' }
@@ -526,11 +527,26 @@ sub set_permissions : Test(7) {
     $obj->get_permissions;
   ok($r2, 'Removed public read access');
 
+  my $zone = $irods->find_zone_name($irods_tmp_coll);
+  ok($obj->set_permissions('read', "public#$zone"),
+     'Set permission using an explicit zone');
+
   dies_ok { $obj->set_permissions('bogus_permission', 'public') }
     'Fails to set bogus permission';
 
   dies_ok { $obj->set_permissions('read', 'bogus_group') }
     'Fails to set permission for bogus group';
+
+ SKIP: {
+    my $version = $irods->installed_baton_version;
+    my ($dotted_version, $commits) = $version =~ m{^(\d+[.]\d+[.]\d+)(\S*)$}msx;
+
+    skip "baton $version is < 0.16.3", 1 unless
+      version->parse($dotted_version) > version->parse('0.16.2');
+
+    dies_ok { $obj->set_permissions('read', 'public#no_such_zone') }
+      'Fails to set permission using a non-existent zone';
+  }
 }
 
 sub get_groups : Test(7) {


### PR DESCRIPTION
The zone given in using this syntax will be honoured only with baton >= 0.16.3. With older
versions, the zone component will be ignored.