### PR TITLE
Muffle expected errors from the lister client.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - PGVERSION="9.3"
     - JANSSON_VERSION="2.7"
     - DNAP_UTILITIES_VERSION="0.5.1"
-    - BATON_VERSION="0.16.3"
+    - BATON_VERSION="0.16.4"
     - CK_DEFAULT_TIMEOUT=10
     - IRODS_VAULT=/usr/local/var/lib/irods/Vault
 

--- a/lib/WTSI/NPG/iRODS.pm
+++ b/lib/WTSI/NPG/iRODS.pm
@@ -9,7 +9,8 @@ use Encode qw(decode);
 use English qw(-no_match_vars);
 use File::Basename qw(basename);
 use File::Spec;
-use List::AllUtils qw(all any uniq);
+use List::AllUtils qw(any uniq);
+use Log::Log4perl::Level;
 use Moose;
 use MooseX::StrictConstructor;
 use Try::Tiny;
@@ -29,8 +30,8 @@ with 'WTSI::DNAP::Utilities::Loggable', 'WTSI::NPG::iRODS::Utilities';
 
 our $VERSION = '';
 
-our $MAX_BATON_VERSION = '0.16.3';
-our $MIN_BATON_VERSION = '0.16.0';
+our $MAX_BATON_VERSION = '0.16.4';
+our $MIN_BATON_VERSION = '0.16.4';
 
 our $IADMIN      = 'iadmin';
 our $ICHKSUM     = 'ichksum';
@@ -2502,9 +2503,21 @@ sub DEMOLISH {
         try {
           $self->debug("Stopping $client client");
           my $startable = $self->$client;
+
+          if ($client eq 'lister') {
+            my $muffled = Log::Log4perl->get_logger('log4perl.logger.Muffled');
+            $muffled->level($OFF);
+            $startable->logger($muffled);
+          }
+
           $startable->stop;
         } catch {
-          $self->error("Failed to stop $client cleanly: ", $_);
+          if ($client eq 'lister') {
+            $self->debug("$client handled expected error: ", $_);
+          }
+          else {
+            $self->error("Failed to stop $client cleanly: ", $_);
+          }
         };
       }
     }

--- a/lib/WTSI/NPG/iRODS/Communicator.pm
+++ b/lib/WTSI/NPG/iRODS/Communicator.pm
@@ -49,7 +49,7 @@ sub communicate {
     $self->error("JSON parse error on: '", ${$self->stdout}, "': ", $_);
   };
 
-  defined $response or
+  $response or
     $self->logconfess("Failed to get a response from JSON spec '$json'");
 
   return $response;

--- a/t/lib/WTSI/NPG/iRODSTest.pm
+++ b/t/lib/WTSI/NPG/iRODSTest.pm
@@ -100,15 +100,21 @@ sub require : Test(1) {
   require_ok('WTSI::NPG::iRODS');
 }
 
-sub compatible_baton_versions : Test(4) {
+sub compatible_baton_versions : Test(5) {
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
                                     strict_baton_version => 0);
 
-  my @compatible_versions = qw(0.16.0
-                               0.16.1
-                               0.16.2
-                               0.16.3);
+  my @incompatible_versions = qw(0.16.0
+                                 0.16.1
+                                 0.16.2
+                                 0.16.3);
 
+  foreach my $version (@incompatible_versions) {
+    ok(!$irods->match_baton_version($version),
+       "Incompatible with baton $version");
+  }
+
+  my @compatible_versions = qw(0.16.4);
   foreach my $version (@compatible_versions) {
     ok($irods->match_baton_version($version),
        "Compatible with baton $version");


### PR DESCRIPTION
We need baton >= 0.16.4 in order to muffle these errors safely.