### PR TITLE
Ensure test dependencies are installed

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -18,7 +18,7 @@ my $build = WTSI::DNAP::Utilities::Build->new
    configure_requires => {
                           'Module::Build'             => '>= 0.42'
                          },
-   test_requires      => {
+   build_requires      => {
                           'Test::Perl::Critic'        => '0',
                           'TAP::Harness'              => '>= 3.30',
                           'Test::Class'               => '>= 0.41',

--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+  - Ensure test dependencies are installed.
+
 Release 2.4.0
 
   - Added a method parameter to allow server-side checksum calculation


### PR DESCRIPTION
Module::Build does not install dependencies listed in 'test_requires'. Test dependencies are available on seq. farm, but absent from the gclp cluster.