### PR TITLE
make_avus_from_objects method with tests; BioNano metadata constants

### DIFF
--- a/lib/WTSI/NPG/iRODS/Metadata.pm
+++ b/lib/WTSI/NPG/iRODS/Metadata.pm
@@ -67,6 +67,11 @@ our @EXPORT = qw(
                   $PACBIO_SOURCE
                   $PACBIO_WELL
 
+                  $BIONANO_CHIP_ID
+                  $BIONANO_FLOWCELL
+                  $BIONANO_INSTRUMENT
+                  $BIONANO_UUID
+
                   $ANALYSIS_UUID
                   $INFINIUM_PROJECT_TITLE
                   $INFINIUM_BEADCHIP
@@ -162,6 +167,12 @@ our $PACBIO_SAMPLE_LOAD_NAME   = 'sample_load_name';
 our $PACBIO_SET_NUMBER         = 'set_number';
 our $PACBIO_SOURCE             = 'source';
 our $PACBIO_WELL               = 'well';
+
+# BioNano
+our $BIONANO_CHIP_ID           = 'bnx_chip_id';
+our $BIONANO_FLOWCELL          = 'bnx_flowcell';
+our $BIONANO_INSTRUMENT        = 'bnx_instrument';
+our $BIONANO_UUID              = 'bnx_uuid';
 
 # Genotyping
 our $ANALYSIS_UUID             = 'analysis_uuid';

--- a/t/lib/WTSI/NPG/iRODSTest.pm
+++ b/t/lib/WTSI/NPG/iRODSTest.pm
@@ -1509,6 +1509,64 @@ sub make_avu : Test(6) {
   } 'AVU must have a non-empty value';
 }
 
+sub make_avus_from_objects: Test(4) {
+
+  {
+    package WTSI::NPG::DeepThought;
+
+    use Moose;
+
+    sub answer {
+      return 42;
+    }
+
+    sub sum_if_even {
+      # return the sum of two arguments, if the sum is even; undef otherwise
+      my ($self, $num1, $num2) = @_;
+      my $sum = $num1 + $num2;
+      if ($sum % 2 == 0) { return $sum; }
+      else { return undef; }
+    }
+
+    no Moose;
+    1;
+  }
+
+  my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
+                                    strict_baton_version => 0);
+  my @objs;
+  for (1 .. 3) { push @objs, WTSI::NPG::DeepThought->new(); }
+  my $args1 = [[1,3], [3,5], [3,6]];
+  # no attribute for arguments [3,6] because sum_if_even returns undef
+  my @expected1 = (
+    {attribute => 'a', value => 4, units => 'florins'},
+    {attribute => 'a', value => 8, units => 'florins'});
+  my @avus1 = $irods->make_avus_from_objects(
+    'a', 'sum_if_even', $args1, \@objs, 'florins'
+  );
+  is_deeply(\@avus1, \@expected1,
+            'AVUs from objects, with arguments and units');
+
+  my $args2 = [];
+  my @expected2 = (
+    {attribute => 'b', value => 42},
+    {attribute => 'b', value => 42},
+    {attribute => 'b', value => 42}, );
+  my @avus2 = $irods->make_avus_from_objects('b', 'answer', $args2, \@objs);
+  is_deeply(\@avus2, \@expected2,
+            'AVUs from objects, without arguments and units');
+
+  my $args3 = [[1,2], [2,3]];
+  dies_ok {$irods->make_avus_from_objects('c', 'sum_if_even', $args3, \@objs)}
+    'Dies with incorrect number of argument ArrayRefs';
+
+  my $args4 = [1, 2, 3];
+  dies_ok {$irods->make_avus_from_objects('d', 'sum_if_even', $args4, \@objs)}
+    'Dies with arguments which are not ArrayRefs';
+
+}
+
+
 sub remote_duplicate_avus : Test(4) {
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
                                     strict_baton_version => 0);

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -16,6 +16,9 @@ allow = until
 [NamingConventions::Capitalization]
 packages = :no_restriction
 
+[Subroutines::ProhibitManyArgs]
+max_arguments = 6
+
 [Subroutines::ProhibitUnusedPrivateSubroutines]
 private_name_regex = _(?!build_)\w+
 


### PR DESCRIPTION
make_avus_from_objects:
- Will be used to create secondary metadata for BioNano, given ArrayRefs of Sample or Study DBIx objects.
- Similarly, can replace WTSI::NPG::HTS::PacBio::Annotator::_make_multi_value_metadata in npg_irods for creation of sample/study AVUs.