### PR TITLE
Option to skip RabbitMQ tests

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -66,6 +66,7 @@ t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
 t/lib/WTSI/NPG/iRODS/GroupAdminTest.pm
 t/lib/WTSI/NPG/iRODS/PerformanceTest.pm
 t/lib/WTSI/NPG/iRODS/PublisherTest.pm
+t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
 t/lib/WTSI/NPG/iRODS/Test.pm
 t/lib/WTSI/NPG/iRODSTest.pm
 t/performance.t

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 export TEST_AUTHOR=1
+export TEST_RABBITMQ=1
 export WTSI_NPG_iRODS_Test_irodsEnvFile=$HOME/.irods/.irodsEnv
 export WTSI_NPG_iRODS_Test_IRODS_ENVIRONMENT_FILE=$HOME/.irods/irods_environment.json
 export WTSI_NPG_iRODS_Test_Resource=testResc

--- a/t/lib/WTSI/NPG/iRODS/ReporterTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/ReporterTest.pm
@@ -72,7 +72,7 @@ use Log::Log4perl;
 use Test::Exception;
 use Test::More;
 
-use base qw[WTSI::NPG::iRODS::Test];
+use base qw[WTSI::NPG::iRODS::TestRabbitMQ];
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
 

--- a/t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
+++ b/t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
@@ -1,0 +1,26 @@
+package WTSI::NPG::iRODS::TestRabbitMQ;
+
+use strict;
+use warnings;
+
+use base qw(WTSI::NPG::iRODS::Test);
+
+# Run full tests (requiring a test RabbitMQ server) only if
+# environment variable TEST_RABBITMQ is true.
+#
+# If TEST_RABBITMQ is true, test configuration is determined by the
+# NPG_RMQ_HOST and NPG_RMQ_CONFIG variables if these are set, or default
+# values otherwise.
+#
+# RabbitMQ checks are run in addition to iRODS checks from
+# WTSI::NPG::iRODS::Test.
+
+sub runtests {
+    my ($self) = @_;
+    if (! $ENV{TEST_RABBITMQ}) {
+	$self->SKIP_CLASS('TEST_RABBITMQ environment variable is false');
+    }
+    return $self->SUPER::runtests;
+}
+
+1;


### PR DESCRIPTION
- Skip RabbitMQ tests in ReporterTest.pm if TEST_RABBITMQ environment variable not set
- Enables these tests to be omitted if RabbitMQ server is not available