### PR TITLE
Toggle RabbitMQ tests with environment variables

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -66,6 +66,7 @@ t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
 t/lib/WTSI/NPG/iRODS/GroupAdminTest.pm
 t/lib/WTSI/NPG/iRODS/PerformanceTest.pm
 t/lib/WTSI/NPG/iRODS/PublisherTest.pm
+t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
 t/lib/WTSI/NPG/iRODS/Test.pm
 t/lib/WTSI/NPG/iRODSTest.pm
 t/performance.t

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 
 export TEST_AUTHOR=1
+export TEST_RABBITMQ=1
 export WTSI_NPG_iRODS_Test_irodsEnvFile=$HOME/.irods/.irodsEnv
 export WTSI_NPG_iRODS_Test_IRODS_ENVIRONMENT_FILE=$HOME/.irods/irods_environment.json
 export WTSI_NPG_iRODS_Test_Resource=testResc

--- a/t/lib/WTSI/NPG/iRODS/ReporterTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/ReporterTest.pm
@@ -72,7 +72,7 @@ use Log::Log4perl;
 use Test::Exception;
 use Test::More;
 
-use base qw[WTSI::NPG::iRODS::Test];
+use base qw[WTSI::NPG::iRODS::TestRabbitMQ];
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
 

--- a/t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
+++ b/t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
@@ -1,0 +1,38 @@
+package WTSI::NPG::iRODS::TestRabbitMQ;
+
+use strict;
+use warnings;
+
+use base qw(WTSI::NPG::iRODS::Test);
+
+# Run full tests (requiring a test RabbitMQ server) only if specified by
+# environment variables:
+#
+# - If TEST_RABBITMQ is set to a false value, skip RabbitMQ tests.
+#
+# - If TEST_RABBITMQ is not set, fall back to TEST_AUTHOR. Run RabbitMQ
+# tests if TEST_AUTHOR is true; skip tests if it is false or undefined.
+#
+# Typical use case: TEST_AUTHOR is true, to enable tests using iRODS.
+# Then default behaviour is to run RabbitMQ tests as well, unless explicitly
+# cancelled by setting TEST_RABBITMQ to false.
+
+sub runtests {
+    my ($self) = @_;
+    my $run_tests;
+    my $skip_msg; # message to print if skipping tests
+    if (! defined $ENV{TEST_RABBITMQ}) {
+        $run_tests = $ENV{TEST_AUTHOR};
+        $skip_msg = 'TEST_RABBITMQ environment variable not set; '.
+            'TEST_AUTHOR false or not set'
+    } else {
+        $run_tests = $ENV{TEST_RABBITMQ};
+        $skip_msg = 'TEST_RABBITMQ environment variable is false';
+    }
+    if (! $run_tests) {
+	$self->SKIP_CLASS($skip_msg);
+    }
+    return $self->SUPER::runtests;
+}
+
+1;


### PR DESCRIPTION
Run full tests (requiring a test RabbitMQ server) only if specified by environment variables:
* If TEST_RABBITMQ is set to a false value, skip RabbitMQ tests.
* If TEST_RABBITMQ is not set, fall back to TEST_AUTHOR. Run RabbitMQ tests if TEST_AUTHOR is true; skip tests if it is false or undefined.

Typical use case: TEST_AUTHOR is true, to enable tests using iRODS. Then default behaviour is to run RabbitMQ tests as well, unless explicitly cancelled by setting TEST_RABBITMQ to false.