### PR TITLE
Do not require that Net::AMQP::RabbitMQ be installed if not using RabbitMQ

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -42,7 +42,6 @@ my $build = WTSI::DNAP::Utilities::Build->new
                           'Moose'                     => '>= 2.1',
                           'MooseX::StrictConstructor' => '>= 0.19',
                           'MooseX::Types'             => '>= 0.45',
-                          'Net::AMQP::RabbitMQ'       => '>= 2.10',
                           'Readonly'                  => '>= 1.04',
                           'Set::Scalar'               => '>= 1.29',
                           'Try::Tiny'                 => '>= 0.22',
@@ -50,6 +49,7 @@ my $build = WTSI::DNAP::Utilities::Build->new
                           'WTSI::DNAP::Utilities'     => '>= 0.5.2',
                          },
    recommends =>         {
+                          'Net::AMQP::RabbitMQ'           => '>= 2.10',
                           'Net::LDAP'                     => '0',
                           'WTSI::DNAP::Warehouse::Schema' => '0',
                          });

--- a/MANIFEST
+++ b/MANIFEST
@@ -23,10 +23,12 @@ lib/WTSI/NPG/iRODS/MetaSearcher.pm
 lib/WTSI/NPG/iRODS/Path.pm
 lib/WTSI/NPG/iRODS/Publisher.pm
 lib/WTSI/NPG/iRODS/Replicate.pm
+lib/WTSI/NPG/iRODS/Reportable.pm
 lib/WTSI/NPG/iRODS/Storable.pm
 lib/WTSI/NPG/iRODS/Types.pm
 lib/WTSI/NPG/iRODS/Utilities.pm
 lib/WTSI/NPG/iRODS/Version.pm
+lib/WTSI/NPG/RabbitMQ/Connectable.pm
 MANIFEST			This list of files
 META.json
 META.yml
@@ -60,15 +62,19 @@ t/data/path/test_dir/contents/c/30.txt
 t/data/path/test_dir/contents/c/z/3.txt
 t/data/path/test_dir/test_file.txt
 t/lib/WTSI/NPG/DriRODSTest.pm
+t/lib/WTSI/NPG/TestMQiRODS.pm
+t/lib/WTSI/NPG/iRODSTest.pm
 t/lib/WTSI/NPG/iRODS/AnnotatorTest.pm
 t/lib/WTSI/NPG/iRODS/CollectionTest.pm
 t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
 t/lib/WTSI/NPG/iRODS/GroupAdminTest.pm
 t/lib/WTSI/NPG/iRODS/PerformanceTest.pm
 t/lib/WTSI/NPG/iRODS/PublisherTest.pm
-t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
+t/lib/WTSI/NPG/iRODS/ReporterTest.pm
 t/lib/WTSI/NPG/iRODS/Test.pm
-t/lib/WTSI/NPG/iRODSTest.pm
+t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
+t/lib/WTSI/NPG/RabbitMQ/TestSubscriber.pm
 t/performance.t
 t/perlcriticrc
 t/publisher.t
+t/reporter.t

--- a/lib/WTSI/NPG/RabbitMQ/Connectable.pm
+++ b/lib/WTSI/NPG/RabbitMQ/Connectable.pm
@@ -7,6 +7,7 @@ use Moose::Role;
 use Cwd qw[abs_path];
 use JSON;
 use File::Slurp qw[read_file];
+
 use Net::AMQP::RabbitMQ;
 
 our $VERSION = '';
@@ -61,7 +62,7 @@ sub _build_connection_opts {
         $opts = from_json(read_file($self->rmq_config_path));
     }
     if ($opts->{'ssl'}) {
-	$opts->{'ssl_cacert'} ||= $SSL_CACERT_DEFAULT;
+        $opts->{'ssl_cacert'} ||= $SSL_CACERT_DEFAULT;
     }
     return $opts;
 }
@@ -137,8 +138,6 @@ sub rmq_cluster_name {
     }
     return $name;
 }
-
-
 
 no Moose::Role;
 

--- a/lib/WTSI/NPG/iRODS.pm
+++ b/lib/WTSI/NPG/iRODS.pm
@@ -314,10 +314,8 @@ has '_permissions_cache' =>
    documentation => 'A cache mapping known iRODS paths to their permissions');
 
 
-with ('WTSI::DNAP::Utilities::Loggable',
-      'WTSI::NPG::iRODS::Reportable',
-      'WTSI::NPG::iRODS::Utilities',
-  );
+with 'WTSI::DNAP::Utilities::Loggable',
+     'WTSI::NPG::iRODS::Utilities';
 
 sub BUILD {
   my ($self) = @_;

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -67,3 +67,5 @@ done
 cd $TRAVIS_BUILD_DIR
 
 cpanm --quiet --notest --installdeps .
+
+cpanm Net::AMQP::RabbitMQ

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -3,7 +3,7 @@
 set -e -u -x
 
 export TEST_AUTHOR=1
-export TEST_RABBITMQ=1
+export TEST_RABBITMQ=0
 export WTSI_NPG_iRODS_Test_irodsEnvFile=$HOME/.irods/.irodsEnv
 export WTSI_NPG_iRODS_Test_IRODS_ENVIRONMENT_FILE=$HOME/.irods/irods_environment.json
 export WTSI_NPG_iRODS_Test_Resource=testResc

--- a/t/lib/WTSI/NPG/RabbitMQ/TestSubscriber.pm
+++ b/t/lib/WTSI/NPG/RabbitMQ/TestSubscriber.pm
@@ -1,0 +1,59 @@
+package WTSI::NPG::RabbitMQ::TestSubscriber;
+
+# simple class to get messages from RabbitMQ for tests
+
+use Moose;
+use JSON;
+
+with 'WTSI::NPG::RabbitMQ::Connectable';
+
+has 'channel' =>
+    (is       => 'ro',
+     isa      => 'Int',
+     default  => 1,
+     documentation => 'A RabbitMQ channel',
+    );
+
+sub BUILD {
+    my ($self, ) = @_;
+    $self->rmq_connect();
+    $self->rmq->channel_open($self->channel);
+}
+
+sub DEMOLISH {
+    my ($self, ) = @_;
+    $self->rmq_disconnect();
+}
+
+sub read_next {
+    my ($self, $queue_name) = @_;
+
+    my $gotten = $self->rmq->get($self->channel, $queue_name);
+    my ($body, $headers);
+    my $body_string = $gotten->{body};
+    if (defined $body_string) {
+        $body = decode_json($body_string);
+        $headers = $gotten->{props}->{headers};
+    }
+    return ($body, $headers);
+}
+
+sub read_all {
+    my ($self, $queue_name) = @_;
+
+    my @messages;
+    my ($body, $headers);
+    do {
+        ($body, $headers) = $self->read_next($queue_name);
+        if (defined $body) {
+            push @messages, [$body, $headers];
+        }
+    } while ($body);
+    return @messages;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+no Moose;
+
+1;

--- a/t/lib/WTSI/NPG/TestMQiRODS.pm
+++ b/t/lib/WTSI/NPG/TestMQiRODS.pm
@@ -1,0 +1,14 @@
+package WTSI::NPG::TestMQiRODS;
+
+use Moose;
+
+use WTSI::NPG::iRODS;
+
+extends 'WTSI::NPG::iRODS';
+with 'WTSI::NPG::iRODS::Reportable';
+
+__PACKAGE__->meta->make_immutable;
+
+no Moose;
+
+1;

--- a/t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
+++ b/t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
@@ -30,7 +30,7 @@ sub runtests {
         $skip_msg = 'TEST_RABBITMQ environment variable is false';
     }
     if (! $run_tests) {
-	$self->SKIP_CLASS($skip_msg);
+        $self->SKIP_CLASS($skip_msg);
     }
     return $self->SUPER::runtests;
 }


### PR DESCRIPTION
Avoid loading Net::AMQP::RabbitMQ in tests when not testing RabbitMQ support

Updated MANIFEST