### PR TITLE
Make internal iRODS.pm method calls private

### DIFF
--- a/lib/WTSI/NPG/iRODS.pm
+++ b/lib/WTSI/NPG/iRODS.pm
@@ -263,6 +263,36 @@ sub absolute_path {
   return $self->_ensure_absolute_path($path);
 }
 
+=head2 list_path_details
+
+  Arg [1]    : An iRODS path.
+
+  Example    : $response = $irods->list_path_details($path)
+  Description: Read details of a given iRODS path: access, AVUs,
+               replicates, and timestamps. The path may represent a data
+               object or a collection. Runs baton-list with the --acl,
+               --avu, --replicate, and --timestamp options in effect, and
+               returns a data structure derived from the JSON output.
+  Returntype : HashRef
+
+=cut
+
+sub list_path_details {
+  my ($self, $path) = @_;
+
+  defined $path or
+    $self->logconfess('A defined path argument is required');
+
+  $path eq q{} and
+    $self->logconfess('A non-empty path argument is required');
+
+  $path = canonpath($path);
+  $path = $self->_ensure_absolute_path($path);
+  $self->debug("Listing details for path '$path'");
+
+  return $self->baton_client->list_path_details($path);
+}
+
 =head2 ensure_collection_path
 
   Arg [1]    : An iRODS path.

--- a/lib/WTSI/NPG/iRODS.pm
+++ b/lib/WTSI/NPG/iRODS.pm
@@ -686,11 +686,18 @@ sub list_collection {
 
   Example    : $irods->add_collection('/my/path/foo')
   Description: Make a new collection in iRODS. Return the new collection.
-  Returntype : Str
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
 
 =cut
 
 sub add_collection {
+  my ($self, $collection) = @_;
+  return $self->_add_collection($collection);
+}
+
+sub _add_collection {
   my ($self, $collection) = @_;
 
   defined $collection or
@@ -716,11 +723,20 @@ sub add_collection {
 
   Example    : $irods->put_collection('/my/path/foo', '/archive')
   Description: Make a new collection in iRODS. Return the new collection.
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
+
   Returntype : Str
 
 =cut
 
 sub put_collection {
+  my ($self, $dir, $target) = @_;
+  return $self->_put_collection($dir, $target);
+}
+
+sub _put_collection {
   my ($self, $dir, $target) = @_;
 
   defined $dir or
@@ -753,11 +769,19 @@ sub put_collection {
 
   Example    : $irods->move_collection('/my/path/a', '/my/path/b')
   Description: Move a collection.
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
 
 sub move_collection {
+    my ($self, $source, $target) = @_;
+    return $self->_move_collection($source, $target);
+}
+
+sub _move_collection {
   my ($self, $source, $target) = @_;
 
   defined $source or
@@ -824,11 +848,20 @@ sub get_collection {
   Example    : $irods->remove_collection('/my/path/foo')
   Description: Remove a collection and contents, recursively, and return
                self.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : WTSI::NPG::iRODS
 
 =cut
 
 sub remove_collection {
+  my ($self, $collection) = @_;
+  return $self->_remove_collection($collection);
+}
+
+sub _remove_collection {
   my ($self, $collection) = @_;
 
   defined $collection or
@@ -882,11 +915,21 @@ sub get_collection_permissions {
   Example    : $irods->set_collection_permissions('read', 'user1', $path)
   Description: Set access permissions on the collection. Return the collection
                path.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
 
+
 sub set_collection_permissions {
+  my ($self, $level, $owner, $collection) = @_;
+  return $self->_set_collection_permissions($level, $owner, $collection);
+}
+
+sub _set_collection_permissions {
   my ($self, $level, $owner, $collection) = @_;
 
   defined $owner or
@@ -1014,11 +1057,20 @@ sub get_collection_meta {
   Example    : $irods->add_collection_avu('/my/path/foo', 'id', 'ABCD1234')
   Description: Add metadata to a collection. Return an array of
                the new attribute, value and units.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Array
 
 =cut
 
 sub add_collection_avu {
+  my ($self, $collection, $attribute, $value, $units) = @_;
+  return $self->_add_collection_avu($collection, $attribute, $value, $units);
+}
+
+sub _add_collection_avu {
   my ($self, $collection, $attribute, $value, $units) = @_;
 
   defined $collection or
@@ -1061,11 +1113,21 @@ sub add_collection_avu {
   Example    : $irods->remove_collection_avu('/my/path/foo', 'id', 'ABCD1234')
   Description: Removes metadata from a collection object. Return the
                collection path.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
 
 sub remove_collection_avu {
+  my ($self, $collection, $attribute, $value, $units) = @_;
+  return $self->_remove_collection_avu($collection, $attribute,
+                                       $value, $units);
+}
+
+sub _remove_collection_avu {
   my ($self, $collection, $attribute, $value, $units) = @_;
 
   defined $collection or
@@ -1117,6 +1179,7 @@ sub remove_collection_avu {
                values will be sorted and concatenated, separated by commas.
                If there are no AVUs specified attribute, an error will be
                raised.
+
   Returntype : HashRef
 
 =cut
@@ -1317,11 +1380,20 @@ sub read_object {
 
   Example    : $irods->add_object('lorem.txt', '/my/path/lorem.txt')
   Description: Add a file to iRODS.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
 
 sub add_object {
+  my ($self, $file, $target, $checksum_action) = @_;
+  return $self->_add_object($file, $target, $checksum_action);
+}
+
+sub _add_object {
   my ($self, $file, $target, $checksum_action) = @_;
 
   defined $file or
@@ -1376,11 +1448,20 @@ sub add_object {
 
   Example    : $irods->replace_object('lorem.txt', '/my/path/lorem.txt')
   Description: Replace a file in iRODS.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
 
 sub replace_object {
+  my ($self, $file, $target, $checksum_action) = @_;
+  return $self->_replace_object($file, $target, $checksum_action);
+}
+
+sub _replace_object {
   my ($self, $file, $target, $checksum_action) = @_;
 
   defined $file or
@@ -1427,11 +1508,20 @@ sub replace_object {
   Description: Copy a data object, including all of its metadata. The
                optional third argument is a callback that may be used to
                translate metadata attributes during the copy.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
 
 sub copy_object {
+  my ($self, $source, $target, $translator) = @_;
+  return $self->_copy_object($source, $target, $translator);
+}
+
+sub _copy_object {
   my ($self, $source, $target, $translator) = @_;
 
   defined $source or
@@ -1472,7 +1562,7 @@ sub copy_object {
       $attr = $translator->($attr);
     }
 
-    $self->add_object_avu($target, $attr, $avu->{value}, $avu->{units});
+    $self->_add_object_avu($target, $attr, $avu->{value}, $avu->{units});
   }
 
   return $target
@@ -1485,11 +1575,20 @@ sub copy_object {
 
   Example    : $irods->move_object('/my/path/lorem.txt', '/my/path/ipsum.txt')
   Description: Move a data object.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
 
 sub move_object {
+  my ($self, $source, $target) = @_;
+  return $self->_move_object($source, $target);
+}
+
+sub _move_object {
   my ($self, $source, $target) = @_;
 
   defined $source or
@@ -1518,6 +1617,10 @@ sub move_object {
 
   Example    : $irods->get_object('/my/path/lorem.txt', 'lorem.txt')
   Description: Fetch a data object and return the path of the local copy.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
@@ -1552,11 +1655,20 @@ sub get_object {
 
   Example    : $irods->remove_object('/my/path/lorem.txt')
   Description: Remove a data object.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
 
 sub remove_object {
+  my ($self, $object) = @_;
+  return $self->_remove_object($object);
+}
+
+sub _remove_object {
   my ($self, $object) = @_;
 
   defined $object or
@@ -1647,11 +1759,20 @@ sub get_object_permissions {
   Example    : $irods->set_object_permissions('read', 'user1', $path)
   Description: Set access permissions on the data objecrt. Return the object
                path.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
 
 sub set_object_permissions {
+  my ($self, $level, $owner, $object) = @_;
+  return $self->_set_object_permissions($level, $owner, $object);
+}
+
+sub _set_object_permissions {
   my ($self, $level, $owner, $object) = @_;
 
   defined $owner or
@@ -1792,11 +1913,19 @@ sub get_object_meta {
 
   Example    : add_object_avu('/my/path/lorem.txt', 'id', 'ABCD1234')
   Description: Add metadata to a data object. Return the object path.
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
 
 sub add_object_avu {
+  my ($self, $object, $attribute, $value, $units) = @_;
+  return $self->_add_object_avu($object, $attribute, $value, $units);
+}
+
+sub _add_object_avu {
   my ($self, $object, $attribute, $value, $units) = @_;
 
   defined $object or
@@ -1843,11 +1972,20 @@ sub add_object_avu {
                'ABCD1234')
   Description: Remove metadata from a data object. Return the object
                path.
+
+               Implemented as a wrapper for a private method. The private
+               method can be called by other methods within the same class,
+               without triggering any message queue updates.
   Returntype : Str
 
 =cut
 
 sub remove_object_avu {
+  my ($self, $object, $attribute, $value, $units) = @_;
+  return $self->_remove_object_avu($object, $attribute, $value, $units);
+}
+
+sub _remove_object_avu {
   my ($self, $object, $attribute, $value, $units) = @_;
 
   defined $object or
@@ -2426,7 +2564,7 @@ sub _stage_object {
     $self->debug("Staging '$file' to '$staging_path'");
     $self->baton_client->put_object($file, $staging_path, @arguments);
     # Tag staging file for easy location with a query
-    $self->add_object_avu($staging_path, $STAGING, 1);
+    $self->_add_object_avu($staging_path, $STAGING, 1);
   } catch {
     $num_errors++;
     my @stack1 = split /\n/msx; # Chop up the stack trace
@@ -2436,7 +2574,7 @@ sub _stage_object {
       # A failed iput may still leave orphaned replicates
       if ($self->is_object($staging_path)) {
         $self->debug("Cleaning up (deleting) staging file '$staging_path'");
-        $self->remove_object($staging_path);
+        $self->_remove_object($staging_path);
       }
     } catch {
       my @stack2 = split /\n/msx;
@@ -2481,18 +2619,18 @@ sub _unstage_object {
           $self->warn("Found $STAGING AVU on published file '$target'");
         }
         else {
-          $self->add_object_avu($staging_path, $avu->{attribute},
-                                $avu->{value}, $avu->{units});
+          $self->_add_object_avu($staging_path, $avu->{attribute},
+                                 $avu->{value}, $avu->{units});
         }
       }
-      $self->remove_object($target);
+      $self->_remove_object($target);
     }
 
     $self->debug("Unstaging '$staging_path' to '$target'");
-    $self->move_object($staging_path, $target);
+    $self->_move_object($staging_path, $target);
 
     # Untag the unstaged file
-    $self->remove_object_avu($target, $STAGING, 1);
+    $self->_remove_object_avu($target, $STAGING, 1);
   } catch {
     $num_errors++;
     my @stack1 = split /\n/msx;
@@ -2500,7 +2638,7 @@ sub _unstage_object {
 
     try {
       $self->debug("Cleaning up (deleting) staging file '$staging_path'");
-      $self->remove_object($staging_path);
+      $self->_remove_object($staging_path);
     } catch {
       my @stack2 = split /\n/msx;
       $self->error("Failed to remove failed staging file '$staging_path': ",

--- a/lib/WTSI/NPG/iRODS/BatonClient.pm
+++ b/lib/WTSI/NPG/iRODS/BatonClient.pm
@@ -535,6 +535,25 @@ sub list_object_meta {
   return $self->_list_path_meta($spec);
 }
 
+sub list_path_details {
+  my ($self, $path) = @_;
+
+  defined $path or
+    $self->logconfess('A defined path argument is required');
+  $path =~ m{^/}msx or
+      $self->logconfess("An absolute path argument is required: ",
+                        "received '$path'");
+
+  my $args = { acl => 1, avu => 1, replicate => 1, timestamp => 1 };
+  my $response = $self->_list_path($path, $args);
+
+  if (exists $response->{error}) {
+    $self->report_error($response);
+  }
+
+  return $response;
+}
+
 sub add_collection_avu {
   my ($self, $collection, $attribute, $value, $units) = @_;
 

--- a/lib/WTSI/NPG/iRODS/BatonClient.pm
+++ b/lib/WTSI/NPG/iRODS/BatonClient.pm
@@ -122,22 +122,24 @@ sub put_object {
   return $remote_path;
 }
 
-sub move_object {
-  my ($self, $source_path, $dest_path) = @_;
+# This is affected by https://github.com/wtsi-npg/baton/issues/189
 
-  my ($data_object, $collection) = fileparse($source_path);
+# sub move_object {
+#   my ($self, $source_path, $dest_path) = @_;
 
-  my $spec = {operation  => 'move',
-              arguments => {path => $dest_path},
-              target     => {collection  => $collection,
-                             data_object => $data_object}};
+#   my ($data_object, $collection) = fileparse($source_path);
 
-  my $response = $self->communicate($spec);
-  $self->validate_response($response);
-  $self->report_error($response);
+#   my $spec = {operation => 'move',
+#               arguments => {path => $dest_path},
+#               target    => {collection  => $collection,
+#                             data_object => $data_object}};
 
-  return $dest_path
-}
+#   my $response = $self->communicate($spec);
+#   $self->validate_response($response);
+#   $self->report_error($response);
+
+#   return $dest_path
+# }
 
 =head2 list_collection
 

--- a/t/lib/WTSI/NPG/iRODS/ReporterTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/ReporterTest.pm
@@ -32,10 +32,9 @@ my $cwc;
 my $test_host = $ENV{'NPG_RMQ_HOST'} || 'localhost';
 my $conf = $ENV{'NPG_RMQ_CONFIG'} || './etc/rmq_test_config.json';
 my $queue = 'test_irods_data_create_messages';
-my $ssubargs = {
-        hostname             => $test_host,
-        rmq_config_path      => $conf,
-    }; # arguments for TestSubscriber creation
+my $subscriber_args_base = {hostname             => $test_host,
+                            rmq_config_path      => $conf,
+                        }; # arguments for TestSubscriber creation
 
 my $irods_class      = 'WTSI::NPG::TestMQiRODS';
 my $subscriber_class = 'WTSI::NPG::RabbitMQ::TestSubscriber';
@@ -44,14 +43,19 @@ my $subscriber_class = 'WTSI::NPG::RabbitMQ::TestSubscriber';
 eval "require $irods_class";
 eval "require $subscriber_class";
 
+# Each test has a channel number, equal to $test_counter. The channel
+# is used by the publisher (iRODS instance) and subscriber in that test only.
+
 sub setup_test : Test(setup) {
-    # clear the message queue
-    my $subscriber = $subscriber_class->new($ssubargs);
+    # Clear the message queue. For a given run of the test harness, each
+    # test has its own RabbitMQ channel; but messages may persist between runs
+    # in a given queue and channel, eg. from previous failed tests.
+    # (Assigning a unique queue name would need reconfiguration of the
+    # RabbitMQ test server.)
+    $test_counter++;
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
-    if (scalar @messages > 0) {
-        $log->warn('Got ', scalar @messages,
-                   ' unread RMQ messages from previous tests');
-    }
     # messaging disabled for test setup
     my $irods = $irods_class->new(environment          => \%ENV,
                                   strict_baton_version => 0,
@@ -62,7 +66,6 @@ sub setup_test : Test(setup) {
         $irods->add_collection("PublisherTest.$pid.$test_counter");
     $remote_file_path = "$irods_tmp_coll/lorem.txt";
     $irods->add_object("$data_path/lorem.txt", $remote_file_path);
-    $test_counter++;
 }
 
 sub teardown_test : Test(teardown) {
@@ -87,11 +90,14 @@ sub test_add_collection : Test(13) {
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                  );
 
     my $irods_new_coll = $irods_tmp_coll.'/temp';
     $irods->add_collection($irods_new_coll);
-    my $subscriber = $subscriber_class->new($ssubargs);
+
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
     is(scalar @messages, 1, 'Got 1 message from queue');
 
@@ -107,13 +113,15 @@ sub test_collection_avu : Test(40) {
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                  );
 
     $irods->add_collection_avu($irods_tmp_coll, 'colour', 'green');
     $irods->add_collection_avu($irods_tmp_coll, 'colour', 'purple');
     $irods->remove_collection_avu($irods_tmp_coll, 'colour', 'green');
 
-    my $subscriber = $subscriber_class->new($ssubargs);
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
     is(scalar @messages, 3, 'Got 3 messages from queue');
 
@@ -151,6 +159,7 @@ sub test_put_move_collection : Test(25) {
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                  );
 
     $irods->put_collection($data_path, $irods_tmp_coll);
@@ -158,7 +167,8 @@ sub test_put_move_collection : Test(25) {
     my $moved_coll = $irods_tmp_coll.'/reporter.moved';
     $irods->move_collection($dest_coll, $moved_coll);
 
-    my $subscriber = $subscriber_class->new($ssubargs);
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
     is(scalar @messages, 2, 'Got 2 messages from queue');
 
@@ -184,9 +194,11 @@ sub test_remove_collection : Test(13) {
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                  );
     $irods->remove_collection($irods_new_coll);
-    my $subscriber = $subscriber_class->new($ssubargs);
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
 
     is(scalar @messages, 1, 'Got 1 message from queue');
@@ -202,6 +214,7 @@ sub test_set_collection_permissions : Test(25) {
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                  );
     my $user = 'public';
     $irods->set_collection_permissions($WTSI::NPG::iRODS::NULL_PERMISSION,
@@ -213,7 +226,8 @@ sub test_set_collection_permissions : Test(25) {
                                        $irods_tmp_coll,
                                    );
 
-    my $subscriber = $subscriber_class->new($ssubargs);
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
     is(scalar @messages, 2, 'Got 2 messages from queue');
 
@@ -227,34 +241,32 @@ sub test_set_collection_permissions : Test(25) {
 
 ### data object tests ###
 
-sub test_add_object : Test(49) {
+sub test_add_object : Test(17) {
 
     my $irods = $irods_class->new(environment          => \%ENV,
                                   strict_baton_version => 0,
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                  );
     my $added_remote_path = "$irods_tmp_coll/lorem_copy.txt";
     $irods->add_object("$data_path/lorem.txt", $added_remote_path);
 
-    my $subscriber = $subscriber_class->new($ssubargs);
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
-    is(scalar @messages, 3, 'Got 3 messages from queue');
 
-    my @methods = qw[add_object_avu remove_object_avu add_object];
-    my $i = 0;
+    is(scalar @messages, 1, 'Got 1 message from queue');
 
-    foreach my $message (@messages) {
-        _test_object_message($message, $methods[$i]);
-        $i++;
-        my ($body, $headers) = @{$message};
-        # temporary staging object is named lorem_copy.txt.[suffix]
-        ok($body->{'data_object'} =~ /^lorem_copy\.txt/msx,
-           'Data object name starts with lorem_copy.txt');
-        ok($body->{'collection'} eq $irods_tmp_coll,
-           "Collection name is $irods_tmp_coll");
-    }
+    my $message = shift @messages;
+    _test_object_message($message, 'add_object');
+    my ($body, $headers) = @{$message};
+    # temporary staging object is named lorem_copy.txt.[suffix]
+    ok($body->{'data_object'} =~ /^lorem_copy\.txt/msx,
+       'Data object name starts with lorem_copy.txt');
+    ok($body->{'collection'} eq $irods_tmp_coll,
+       "Collection name is $irods_tmp_coll");
 }
 
 sub test_copy_object : Test(17) {
@@ -264,17 +276,18 @@ sub test_copy_object : Test(17) {
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                 );
     my $copied_remote_path = "$irods_tmp_coll/lorem_copy.txt";
     $irods->copy_object($remote_file_path, $copied_remote_path);
 
-    my $subscriber = $subscriber_class->new($ssubargs);
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
     is(scalar @messages, 1, 'Got 1 message from queue');
 
-    my $method = 'copy_object';
     my $message = shift @messages;
-    _test_object_message($message, $method);
+    _test_object_message($message, 'copy_object');
 
     my ($body, $headers) = @{$message};
     ok($body->{'data_object'} eq 'lorem_copy.txt',
@@ -290,17 +303,18 @@ sub test_move_object : Test(17) {
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                  );
     my $moved_remote_path = "$irods_tmp_coll/lorem_moved.txt";
     $irods->move_object($remote_file_path, $moved_remote_path);
 
-    my $subscriber = $subscriber_class->new($ssubargs);
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
     is(scalar @messages, 1, 'Got 1 message from queue');
 
-    my $method = 'move_object';
     my $message = shift @messages;
-    _test_object_message($message, $method);
+    _test_object_message($message, 'move_object');
 
     my ($body, $headers) = @{$message};
     ok($body->{'data_object'} eq 'lorem_moved.txt',
@@ -316,13 +330,15 @@ sub test_object_avu : Test(52) {
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                  );
 
     $irods->add_object_avu($remote_file_path, 'colour', 'green');
     $irods->add_object_avu($remote_file_path, 'colour', 'purple');
     $irods->remove_object_avu($remote_file_path, 'colour', 'green');
 
-    my $subscriber = $subscriber_class->new($ssubargs);
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
     is(scalar @messages, 3, 'Got 3 messages from queue');
 
@@ -362,9 +378,11 @@ sub test_remove_object : Test(15) {
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                  );
     $irods->remove_object($remote_file_path);
-    my $subscriber = $subscriber_class->new($ssubargs);
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
 
     is(scalar @messages, 1, 'Got 1 message from queue');
@@ -374,37 +392,30 @@ sub test_remove_object : Test(15) {
     _test_object_message($message, $method);
 }
 
-sub test_replace_object : Test(65) {
+sub test_replace_object : Test(17) {
 
     my $irods = $irods_class->new(environment          => \%ENV,
                                   strict_baton_version => 0,
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                  );
     $irods->replace_object("$data_path/lorem.txt", $remote_file_path);
 
-    my $subscriber = $subscriber_class->new($ssubargs);
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
+    is(scalar @messages, 1, 'Got 1 message from queue');
 
-    is(scalar @messages, 4, 'Got 4 messages from queue');
-
-    my @methods = qw[add_object_avu
-                     remove_object
-                     remove_object_avu
-                     replace_object];
-    my $i = 0;
-
-    foreach my $message (@messages) {
-        _test_object_message($message, $methods[$i]);
-        $i++;
-        my ($body, $headers) = @{$message};
-        # temporary staging object is named lorem.txt.[suffix]
-        ok($body->{'data_object'} =~ /^lorem\.txt/msx,
-           'Data object name starts with lorem.txt');
-        ok($body->{'collection'} eq $irods_tmp_coll,
-           "Collection name is $irods_tmp_coll");
-    }
+    my $message = shift @messages;
+    _test_object_message($message, 'replace_object');
+    my ($body, $headers) = @{$message};
+    # temporary staging object is named lorem.txt.[suffix]
+    ok($body->{'data_object'} =~ /^lorem\.txt/msx,
+       'Data object name starts with lorem.txt');
+    ok($body->{'collection'} eq $irods_tmp_coll,
+       "Collection name is $irods_tmp_coll");
 }
 
 sub test_set_object_permissions : Test(29) {
@@ -414,6 +425,7 @@ sub test_set_object_permissions : Test(29) {
                                   routing_key_prefix   => 'test',
                                   hostname             => $test_host,
                                   rmq_config_path      => $conf,
+                                  channel              => $test_counter,
                                  );
     my $user = 'public';
     $irods->set_object_permissions($WTSI::NPG::iRODS::NULL_PERMISSION,
@@ -424,7 +436,8 @@ sub test_set_object_permissions : Test(29) {
                                    $user,
                                    $remote_file_path,
                                );
-    my $subscriber = $subscriber_class->new($ssubargs);
+    my $subscriber_args = _get_subscriber_args($test_counter);
+    my $subscriber = $subscriber_class->new($subscriber_args);
     my @messages = $subscriber->read_all($queue);
     is(scalar @messages, 2, 'Got 2 messages from queue');
     my $method = 'set_object_permissions';
@@ -436,8 +449,19 @@ sub test_set_object_permissions : Test(29) {
 
 ### methods for repeated tests ###
 
+sub _get_subscriber_args {
+    my ($channel, ) = @_;
+    my $args = {
+        hostname             => $test_host, # global variable
+        rmq_config_path      => $conf,      # global variable
+        channel              => $channel,
+    };
+    return $args;
+}
+
 sub _test_collection_message {
     my ($message, $method) = @_;
+    # total tests = 12
     my ($body, $headers) = @{$message};
     my @body_keys_coll = qw[collection
                             timestamps
@@ -462,6 +486,7 @@ sub _test_collection_message {
 
 sub _test_object_message {
     my ($message, $method) = @_;
+    # total tests = 14
     my ($body, $headers) = @{$message};
     my @body_keys_obj = qw[collection
                            data_object


### PR DESCRIPTION
- Methods which are subject to RabbitMQ reporting have been implemented as wrappers around private methods. Calls to the public method are reportable; those to the private method are not.
- Calls within iRODS.pm use the private methods. This reduces RabbitMQ message volume, and ensures only one message is produced for each call to the iRODS API.
- Each test in ReporterTest.pm now uses a separate RabbitMQ message channel, to reduce the scope for message spillover between tests.