### PR TITLE
Additional tests, bugfix and comments for RabbitMQ

### DIFF
--- a/lib/WTSI/NPG/iRODS/Reportable.pm
+++ b/lib/WTSI/NPG/iRODS/Reportable.pm
@@ -172,7 +172,7 @@ sub _publish_message {
     my $response = $self->list_path_details($path);
     my $response_string = encode_json($response);
     $self->debug('Got response from baton: ', $response_string);
-    my $key = $self->routing_key_prefix.'.irods.data.create';
+    my $key = $self->routing_key_prefix.'.irods.report';
     my $headers = $self->_get_headers($response, $name, $now);
     $self->rmq->publish($self->channel,
                         $key,
@@ -180,6 +180,8 @@ sub _publish_message {
                         { exchange => $self->exchange },
                         { headers => $headers },
                     );
+    # Net::AMQP::RabbitMQ documentation specifies 'header' as key in
+    # props argument to 'publish', but this is incorrect (2017-07-31)
     return 1;
 }
 

--- a/scripts/rabbitmq_config.pl
+++ b/scripts/rabbitmq_config.pl
@@ -18,32 +18,41 @@ my $host = $ENV{'NPG_RMQ_HOST'};
 my $opts = from_json(read_file($ENV{'NPG_RMQ_CONFIG'}));
 
 $rmq->connect($host, $opts);
-$rmq->channel_open($channel);
-$rmq->exchange_declare(
-    $channel,
-    $exchange_gateway,
-    { exchange_type => 'fanout' },
-);
-$rmq->exchange_declare(
-    $channel,
-    $exchange_activity,
-    { exchange_type => 'topic' },
-);
-$rmq->queue_declare(
-    $channel,
-    $queue,
-);
-$rmq->exchange_bind(
-    $channel,
-    $exchange_activity,
-    $exchange_gateway,
-    'test.irods.*',
-);
-$rmq->queue_bind(
-    $channel,
-    $queue,
-    $exchange_activity,
-    'test.irods.*',
-);
+
+# We want to increment the channel number for each test
+# So we declare 100 channels (many more than currently needed)
+
+while ($channel <= 100) {
+
+    $rmq->channel_open($channel);
+    $rmq->exchange_declare(
+        $channel,
+        $exchange_gateway,
+        { exchange_type => 'fanout' },
+    );
+    $rmq->exchange_declare(
+        $channel,
+        $exchange_activity,
+        { exchange_type => 'topic' },
+    );
+    $rmq->queue_declare(
+        $channel,
+        $queue,
+    );
+    $rmq->exchange_bind(
+        $channel,
+        $exchange_activity,
+        $exchange_gateway,
+        'test.irods.*',
+    );
+    $rmq->queue_bind(
+        $channel,
+        $queue,
+        $exchange_activity,
+        'test.irods.*',
+    );
+
+    $channel++;
+}
 
 $rmq->disconnect();

--- a/t/lib/WTSI/NPG/RabbitMQ/TestCommunicator.pm
+++ b/t/lib/WTSI/NPG/RabbitMQ/TestCommunicator.pm
@@ -1,6 +1,6 @@
-package WTSI::NPG::RabbitMQ::TestSubscriber;
+package WTSI::NPG::RabbitMQ::TestCommunicator;
 
-# simple class to get messages from RabbitMQ for tests
+# simple class to send/receive RabbitMQ messages for tests
 
 use Moose;
 use JSON;
@@ -23,6 +23,23 @@ sub BUILD {
 sub DEMOLISH {
     my ($self, ) = @_;
     $self->rmq_disconnect();
+}
+
+sub publish {
+    my ($self, $body, $exchange, $routing_key) = @_;
+    $exchange ||= 'npg.gateway';
+    $routing_key ||= 'test.irods.rmq_publish';
+    my $options = { exchange => $exchange };
+    my $time = localtime;
+    my $header = { time => $time };
+    my $props = { headers => $header };
+    # Net::AMQP::RabbitMQ documentation specifies 'header' as key in
+    # props argument to 'publish', but this is incorrect (2017-07-31)
+    $self->rmq->publish($self->channel,
+                        $routing_key,
+                        $body,
+                        $options,
+                        $props);
 }
 
 sub read_next {


### PR DESCRIPTION
- Bugfix: Change default routing key to match pattern in Travis test config
- Declare a separate RabbitMQ channel for each test
- Rename TestSubscriber as TestCommunicator and add a 'publish' method
- Add a 'sanity check' test of TestCommunicator and message queue to ReporterTest.pm
- If no message is read from the test queue, skip subsequent tests
