### PR TITLE
Add ACL to RabbitMQ message body and fix merge conflicts

### DIFF
--- a/t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
+++ b/t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
@@ -33,8 +33,8 @@ sub runtests {
     }
     if (! $run_tests) {
         diag('Omitting RabbitMQ tests: Either TEST_RABBITMQ is set to ',
-	     'false; or TEST_RABBITMQ is not set, and TEST_AUTHOR ',
-	     'is false or not set');
+             'false; or TEST_RABBITMQ is not set, and TEST_AUTHOR ',
+             'is false or not set');
         $self->SKIP_CLASS($skip_msg);
     }
     return $self->SUPER::runtests;


### PR DESCRIPTION
- Add ACL to the RabbitMQ message body
- Public methods to create message header and body in WTSI/NPG/iRODS/Reportable/Base.pm
- Use get_[object|collection]_permissions to find ACL; uses cached values where available
- Update tests