### PR TITLE
Move 'use' statements into TestRabbitMQ

### DIFF
--- a/t/lib/WTSI/NPG/iRODS/ReporterTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/ReporterTest.pm
@@ -16,10 +16,6 @@ Log::Log4perl::init('./etc/log4perl_tests.conf');
 
 my $log = Log::Log4perl::get_logger();
 
-use WTSI::NPG::iRODSMQTest;
-use WTSI::NPG::PublisherMQTest;
-use WTSI::NPG::RabbitMQ::TestCommunicator;
-
 my $pid          = $PID;
 my $test_counter = 0;
 my $data_path    = './t/data/reporter';

--- a/t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
+++ b/t/lib/WTSI/NPG/iRODS/TestRabbitMQ.pm
@@ -36,6 +36,11 @@ sub runtests {
 	     'false; or TEST_RABBITMQ is not set, and TEST_AUTHOR ',
 	     'is false or not set');
         $self->SKIP_CLASS($skip_msg);
+    } else {
+	# optional modules, needed for RabbitMQ tests
+	require WTSI::NPG::iRODSMQTest;
+	require WTSI::NPG::PublisherMQTest;
+	require WTSI::NPG::RabbitMQ::TestCommunicator;
     }
     return $self->SUPER::runtests;
 }


### PR DESCRIPTION
Packages depend on Net::AMQP::RabbitMQ:
- WTSI::NPG::iRODSMQTest
- WTSI::NPG::PublisherMQTest
- WTSI::NPG::RabbitMQ::TestCommunicator

The 'use' statements in WTSI/NPG/iRODS/ReporterTest.pm imported these packages even when RabbitMQ tests were being skipped. This cased an error when Net::AMQP::RabbitMQ was not installed. Instead, 'require' statements have been put in WTSI/NPG/iRODS/TestRabbitMQ.pm, so the packages are only imported if they are actually going to be used.