### PR TITLE
Fixed null dereference in Collection::collection_checksums

### DIFF
--- a/lib/WTSI/NPG/iRODS.pm
+++ b/lib/WTSI/NPG/iRODS.pm
@@ -2146,6 +2146,19 @@ sub checksum {
   return $self->baton_client->list_object_checksum($object);
 }
 
+=head2 collection_checksums
+
+  Arg [1]    : iRODS collection path.
+  Arg [2]    : Recurse, Bool. Optional, defaults to false.
+
+  Example    : $cs = $irods->collection_checksums('/my/path/')
+  Description: Return the MD5 checksum of the iRODS data objects in a
+               collection as a mapping of data object path to corresponding
+               checksum.
+  Returntype : HashRef
+
+=cut
+
 sub collection_checksums {
   my ($self, $collection, $recurse) = @_;
 

--- a/lib/WTSI/NPG/iRODS/BatonClient.pm
+++ b/lib/WTSI/NPG/iRODS/BatonClient.pm
@@ -211,6 +211,20 @@ sub list_object {
   return $path;
 }
 
+=head2 list_collection_checksums
+
+  Arg [1]    : iRODS collection path.
+  Arg [2]    : Recurse, Bool. Optional, defaults to false.
+
+  Example    : my $checksums =
+                 $irods->list_collection_checksums('/path/to/collection')
+  Description: Return the checksums of the data objects in a collection
+               as a mapping of data object path to corresponding checksum.
+               This method is present for speed.
+  Returntype : HashRef
+
+=cut
+
 sub list_collection_checksums {
   my ($self, $collection, $recur) = @_;
 

--- a/t/lib/WTSI/NPG/iRODS/CollectionTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/CollectionTest.pm
@@ -235,7 +235,7 @@ sub str : Test(1) {
   is($coll->str, $coll_path, 'Collection string');
 }
 
-sub get_contents : Test(4) {
+sub get_contents : Test(8) {
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
                                     strict_baton_version => 0);
   my $coll_path = "$irods_tmp_coll/path/test_dir/contents";
@@ -282,6 +282,26 @@ sub get_contents : Test(4) {
 
   is_deeply(\@coll_paths_r, $expected_colls_r, 'Collection recursive contents')
     or diag explain \@coll_paths_r;
+
+  # Checksums read individually, on demand
+  my @checksums_r = map { $_->checksum } @$objs_r;
+  is_deeply(\@checksums_r, [('d41d8cd98f00b204e9800998ecf8427e') x 6 ],
+            'Object checksums') or diag explain \@checksums_r;
+
+  my ($objs_rc, $colls_rc) = $coll->get_contents('RECURSE', 'CHECKSUM');
+  my @obj_paths_rc  = map { $_->str } @$objs_r;
+  my @coll_paths_rc = map { $_->str } @$colls_r;
+
+  is_deeply(\@obj_paths_rc, $expected_objs_r, 'Object recursive contents')
+    or diag explain \@obj_paths_rc;
+
+  is_deeply(\@coll_paths_rc, $expected_colls_r, 'Collection recursive contents')
+    or diag explain \@coll_paths_rc;
+
+  # Checksums fetched as a batch
+  my @checksums_rc = map { $_->checksum } @$objs_rc;
+  is_deeply(\@checksums_r, [('d41d8cd98f00b204e9800998ecf8427e') x 6 ],
+            'Object checksums') or diag explain \@checksums_rc;
 }
 
 sub get_permissions : Test(1) {


### PR DESCRIPTION
Fixed a long-standing bug in Collection.pm where using the checksum argument resulted in a null dereference.

Added POD and tests.