### PR TITLE
checksum bug fix in put_object method

### DIFF
--- a/lib/WTSI/NPG/iRODS/BatonClient.pm
+++ b/lib/WTSI/NPG/iRODS/BatonClient.pm
@@ -105,16 +105,11 @@ sub is_object {
 sub put_object {
   my ($self, $local_path, $remote_path, $checksum) = @_;
 
-  my $args = {};
-  if ($checksum) {
-    $args->{calculate_checksum} = 1;
-  }
-
   my ($file_name, $directory, $suffix) = fileparse($local_path);
   my ($data_object, $collection) = fileparse($remote_path);
 
   my $spec = {operation => 'put',
-              arguments => $self->_map_json_args($args),
+              arguments => $self->_map_json_args({checksum => $checksum}),
               target    => {collection  => $collection,
                             data_object => $data_object,
                             directory   => $directory,


### PR DESCRIPTION
The bug fix itself is passing the correct option to baton v 2.0.0, 'checksum' instead of 'calculate_checksum'. The options is now always passed, i.e. the Perl wrapper does not rely on baton's default behaviour in respect of server-side calculation of checksums.

It seems that when not checksum is associated with an object, an undefined value is now returned rather than an empty string; this is reflected in the tests.

Blocks of tests that examined checksums and previously marked marked as TODO are now passing.