### PR TITLE
Change gbs_plex to primer_panel in Metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Upcoming
 
- -
+ -Rename GBS_PLEX_NAME = gbs_plex to primer_panel in Metadata 
+  to match field in mlwarehouse.
 
 Release 3.11.0
 

--- a/lib/WTSI/NPG/iRODS/Metadata.pm
+++ b/lib/WTSI/NPG/iRODS/Metadata.pm
@@ -172,7 +172,7 @@ our $XAHUMAN                   = 'xahuman';
 our $YHUMAN                    = 'yhuman';
 
 # Genotyping by Sequencing (Illumina)
-our $GBS_PLEX_NAME             = 'gbs_plex';
+our $GBS_PLEX_NAME             = 'primer_panel';
 
 # Composition and component JSON strings
 # and a unique product id based on composition


### PR DESCRIPTION
Take advantage of 1 year hiatus to rename gbs_plex (used within NPG genotyping by sequencing flow) to primer_panel so the iRODS meta data field will be consistent with the field name PSD chose to use in the iseq_flowcell table in the mlwarehouse.