### PR TITLE
Switch from List::AllUtils to List::MoreUtils implementation of 'zip'

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -39,7 +39,7 @@ my $build = WTSI::DNAP::Utilities::Build->new
                           'IPC::Run'                  => '>= 0.92',
                           'JSON'                      => '>= 2.90',
                           'Log::Log4perl'             => '>= 1.46',
-                          'List::AllUtils'            => '>= 0.09',
+                          'List::MoreUtils'           => '0',
                           'Moose'                     => '>= 2.1',
                           'MooseX::StrictConstructor' => '>= 0.19',
                           'MooseX::Types'             => '>= 0.45',
@@ -47,7 +47,7 @@ my $build = WTSI::DNAP::Utilities::Build->new
                           'Set::Scalar'               => '>= 1.29',
                           'Try::Tiny'                 => '>= 0.22',
                           'URI'                       => '>= 1.67',
-			  'UUID'                      => '>= 0.27',
+			                    'UUID'                      => '>= 0.27',
                           'WTSI::DNAP::Utilities'     => '>= 0.5.2',
                          },
    recommends =>         {

--- a/Build.PL
+++ b/Build.PL
@@ -47,7 +47,7 @@ my $build = WTSI::DNAP::Utilities::Build->new
                           'Set::Scalar'               => '>= 1.29',
                           'Try::Tiny'                 => '>= 0.22',
                           'URI'                       => '>= 1.67',
-			                    'UUID'                      => '>= 0.27',
+                          'UUID'                      => '>= 0.27',
                           'WTSI::DNAP::Utilities'     => '>= 0.5.2',
                          },
    recommends =>         {

--- a/bin/miget.pl
+++ b/bin/miget.pl
@@ -7,7 +7,7 @@ use lib (-d "$Bin/../lib/perl5" ? "$Bin/../lib/perl5" : "$Bin/../lib");
 
 use Cwd qw(abs_path getcwd);
 use Getopt::Long;
-use List::AllUtils qw(uniq);
+use List::MoreUtils qw(uniq);
 use Log::Log4perl;
 use Log::Log4perl::Level;
 use Pod::Usage;

--- a/lib/WTSI/NPG/iRODS.pm
+++ b/lib/WTSI/NPG/iRODS.pm
@@ -9,7 +9,7 @@ use Encode qw(decode);
 use English qw(-no_match_vars);
 use File::Basename qw(basename fileparse);
 use File::Spec::Functions qw(abs2rel canonpath catdir catfile splitdir);
-use List::AllUtils qw(any uniq);
+use List::MoreUtils qw(any uniq);
 use Log::Log4perl::Level;
 use Moose;
 use MooseX::StrictConstructor;

--- a/lib/WTSI/NPG/iRODS/Annotator.pm
+++ b/lib/WTSI/NPG/iRODS/Annotator.pm
@@ -1,7 +1,7 @@
 package WTSI::NPG::iRODS::Annotator;
 
 use DateTime;
-use List::AllUtils qw[uniq];
+use List::MoreUtils qw[uniq];
 use Moose::Role;
 
 use WTSI::NPG::iRODS::Metadata;

--- a/lib/WTSI/NPG/iRODS/DataObject.pm
+++ b/lib/WTSI/NPG/iRODS/DataObject.pm
@@ -2,7 +2,7 @@ package WTSI::NPG::iRODS::DataObject;
 
 use namespace::autoclean;
 use File::Spec;
-use List::AllUtils qw(none uniq);
+use List::MoreUtils qw(none uniq);
 use Moose;
 use MooseX::StrictConstructor;
 use Set::Scalar;

--- a/lib/WTSI/NPG/iRODS/GroupAdmin.pm
+++ b/lib/WTSI/NPG/iRODS/GroupAdmin.pm
@@ -7,7 +7,7 @@ use MooseX::StrictConstructor;
 use IPC::Run qw(start run);
 use File::Which qw(which);
 use Cwd qw(abs_path);
-use List::AllUtils qw(any none);
+use List::MoreUtils qw(any none);
 use Log::Log4perl;
 use Readonly;
 use Carp;
@@ -300,7 +300,7 @@ Will honour iRODS related environment at time of object creation
 
 =item Cwd
 
-=item List::AllUtils
+=item List::MoreUtils
 
 =item Readonly
 

--- a/lib/WTSI/NPG/iRODS/Path.pm
+++ b/lib/WTSI/NPG/iRODS/Path.pm
@@ -2,7 +2,7 @@ package WTSI::NPG::iRODS::Path;
 
 use Data::Dump qw(pp);
 use File::Spec;
-use List::AllUtils qw(any notall uniq);
+use List::MoreUtils qw(any notall uniq);
 use Moose::Role;
 
 use WTSI::NPG::iRODS;

--- a/lib/WTSI/NPG/iRODS/Publisher.pm
+++ b/lib/WTSI/NPG/iRODS/Publisher.pm
@@ -8,7 +8,7 @@ use English qw[-no_match_vars];
 use File::Basename;
 use File::Spec::Functions qw[catdir catfile splitdir splitpath];
 use File::stat;
-use List::AllUtils qw[any];
+use List::MoreUtils qw[any];
 use Moose;
 use Try::Tiny;
 

--- a/lib/WTSI/NPG/iRODS/Utilities.pm
+++ b/lib/WTSI/NPG/iRODS/Utilities.pm
@@ -1,7 +1,7 @@
 package WTSI::NPG::iRODS::Utilities;
 
 use Digest::MD5;
-use List::AllUtils qw(uniq zip);
+use List::MoreUtils qw(uniq zip);
 use Moose::Role;
 
 use WTSI::DNAP::Utilities::Runnable;

--- a/t/lib/WTSI/NPG/DriRODSTest.pm
+++ b/t/lib/WTSI/NPG/DriRODSTest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use English qw(-no_match_vars);
 use File::Temp;
-use List::AllUtils qw(none);
+use List::MoreUtils qw(none);
 use Log::Log4perl;
 
 use base qw(WTSI::NPG::iRODS::Test);

--- a/t/lib/WTSI/NPG/iRODS/CollectionTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/CollectionTest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use English qw(-no_match_vars);
 use File::Spec;
-use List::AllUtils qw(all any none);
+use List::MoreUtils qw(all any none);
 use Log::Log4perl;
 
 use base qw(WTSI::NPG::iRODS::Test);

--- a/t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/DataObjectTest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use English qw(-no_match_vars);
 use File::Spec;
-use List::AllUtils qw(all any none);
+use List::MoreUtils qw(all any none);
 use Log::Log4perl;
 
 use base qw(WTSI::NPG::iRODS::Test);

--- a/t/lib/WTSI/NPG/iRODS/PerformanceTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/PerformanceTest.pm
@@ -5,7 +5,7 @@ use warnings;
 use Benchmark qw(:all);
 use English qw(-no_match_vars);
 use File::Temp qw(tempdir);
-use List::AllUtils qw(any);
+use List::MoreUtils qw(any);
 
 use base qw(WTSI::NPG::iRODS::Test);
 use Test::More;

--- a/t/lib/WTSI/NPG/iRODSTest.pm
+++ b/t/lib/WTSI/NPG/iRODSTest.pm
@@ -9,7 +9,7 @@ use warnings;
 use English qw(-no_match_vars);
 use File::Spec;
 use File::Temp qw(tempdir);
-use List::AllUtils qw(all any none);
+use List::MoreUtils qw(all any none);
 use Log::Log4perl;
 use Try::Tiny;
 use Unicode::Collate;


### PR DESCRIPTION
List::AllUtils exposes functions from List::Util in preference to any
others. We were using a 'zip' function exposed by List::AllUtils that
was not from List::Util, which accepted two arrays.

List::Util 1.56 has added a 'zip' function which accepts two
arrayrefs, which is now exposed by List::AllUtils instead of the
previously exposed implementation.

This change caused our make_avus_from_objects method to fail (this is
used in one place in npg_irods). This change uses List::MoreUtils
'zip' implementation explicitly.