### PR TITLE
Add baton 3.0.0, remove baton 2.1.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,17 +19,13 @@ jobs:
     strategy:
       matrix:
         perl: [ "5.22.4" ]
-        baton: [ "2.1.0" ]
+        baton: [ "3.0.0" ]
         experimental: [ false ]
         include:
           - irods: "4.2.7"
             server_image: "wsinpg/ub-16.04-irods-4.2.7:latest"
-            baton: "2.1.0"
-            experimental: false
           - irods: "4.2.8"
             server_image: "wsinpg/ub-18.04-irods-4.2.8:latest"
-            baton: "2.1.0"
-            experimental: true
 
     services:
       irods:
@@ -61,7 +57,6 @@ jobs:
 
           conda config --set auto_update_conda False
           conda config --prepend channels "$WSI_CONDA_CHANNEL"
-          conda config --append channels conda-forge
           conda info
 
       - name: "Install iRODS clients"


### PR DESCRIPTION
Remove conda-forge from Conda channels as it is not required for any
dependencies of baton 3.0.0.

Depends on https://github.com/wtsi-npg/npg_conda/pull/253