### PR TITLE
Remove -T option from icommands execution

### DIFF
--- a/lib/WTSI/NPG/iRODS.pm
+++ b/lib/WTSI/NPG/iRODS.pm
@@ -1605,7 +1605,7 @@ sub get_object {
   $source = $self->ensure_object_path($source);
   $target = $self->_ensure_absolute_path($target);
 
-  my @args = ('-f', '-T', $source, $target);
+  my @args = ('-f', $source, $target);
   my $runnable = WTSI::DNAP::Utilities::Runnable->new
     (executable  => $IGET,
      arguments   => \@args)->run;


### PR DESCRIPTION
One line change: The aim is to remove -T option from icommand calls because it may cause the connection to freeze after 10 minute when the collection retrieval hangs, with a cliReconnManager: Reconnecting clientState = 0 message.