### PR TITLE
Update ci test workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,17 +23,12 @@ jobs:
           - perl: "5.22.4"
             irods: "4.2.7"
             server_image: "wsinpg/ub-16.04-irods-4.2.7:latest"
-            baton: "3.2.0"
-            experimental: false
-          - perl: "5.22.4"
-            irods: "4.2.10"
-            server_image: "wsinpg/ub-18.04-irods-4.2.10:latest"
-            baton: "3.2.0"
+            baton: "3.3.0"
             experimental: false
           - perl: "5.22.4"
             irods: "4.2.11"
             server_image: "wsinpg/ub-18.04-irods-4.2.11:latest"
-            baton: "3.2.0"
+            baton: "3.3.0"
             experimental: false
 
     services:

--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+ - Update baton version in github actions workflow to 3.3.0
+ - Remove iRODS 4.2.10 from github actions workflow
+
 Release 3.17.0
 
  - Add SamHaplotag files


### PR DESCRIPTION
Update baton version to 3.3.0 and remove irods 4.2.10 from actions test workflow