### PR TITLE
Update test matrix iRODS versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,10 +21,15 @@ jobs:
         include:
           - perl: "5.22.4"
             irods: "4.2.7"
-            client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.11:latest"
+            client_image: "ghcr.io/wtsi-npg/ub-16.04-irods-clients-4.2.7:latest"
             server_image: "ghcr.io/wtsi-npg/ub-16.04-irods-4.2.7:latest"
             experimental: false
           - perl: "5.22.4"
+            irods: "4.2.11"
+            client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.11:latest"
+            server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.11:latest"
+            experimental: false
+          - perl: "5.34.1"
             irods: "4.2.11"
             client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.11:latest"
             server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.11:latest"
@@ -34,10 +39,10 @@ jobs:
             client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.12:latest"
             server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.12:latest"
             experimental: false
-          - perl: "5.34.1"
-            irods: "4.2.11"
-            client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.11:latest"
-            server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.11:latest"
+          - perl: "5.22.4"
+            irods: "4.3.0"
+            client_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-4.3-nightly:latest"
+            server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3-nightly:latest"
             experimental: true
 
     services:
@@ -101,7 +106,6 @@ jobs:
       - name: "Configure iRODS clients"
         env:
           DOCKER_IMAGE: ${{ matrix.client_image }}
-          PREFIX: ${{ github.workspace }}
         run: |
           mkdir -p "$HOME/.irods"
           cat <<'EOF' > "$HOME/.irods/irods_environment.json"

--- a/t/lib/WTSI/NPG/iRODS/GroupAdminTest.pm
+++ b/t/lib/WTSI/NPG/iRODS/GroupAdminTest.pm
@@ -20,7 +20,7 @@ my $have_admin_rights =
 my $group_prefix = 'ss_';
 
 # Groups to be added to the test iRODS
-my @irods_groups = map { $group_prefix . $_ } (0 .. 100);
+my @irods_groups = map { $group_prefix . $_ } (0 .. 5);
 my @irods_users = qw(user_foo user_bar);
 
 my $test_irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
@@ -76,8 +76,9 @@ sub lg : Test(5) {
       skip 'No admin rights to create test groups', 2;
     }
 
-    my @observed_groups = sort $iga->lg;
-    my @expected_groups = sort ('public', 'rodsadmin', @irods_groups);
+    # Ignore the rodsadmin group as it is not present in iRODS >4.3.0
+    my @observed_groups = sort grep { $_ ne 'rodsadmin' } $iga->lg;
+    my @expected_groups = sort ('public', @irods_groups);
     is_deeply(\@observed_groups, \@expected_groups, 'Expected groups found') or
       diag explain \@observed_groups;
 

--- a/t/lib/WTSI/NPG/iRODSTest.pm
+++ b/t/lib/WTSI/NPG/iRODSTest.pm
@@ -231,14 +231,14 @@ sub list_groups : Test(1) {
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
                                     strict_baton_version => 0);
 
-  ok(grep { /^rodsadmin$/ } $irods->list_groups, 'Listed the rodsadmin group');
+  ok(grep { /^public/ } $irods->list_groups, 'Listed the public group');
 }
 
 sub group_exists : Test(2) {
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
                                     strict_baton_version => 0);
 
-  ok($irods->group_exists('rodsadmin'), 'The rodsadmin group exists');
+  ok($irods->group_exists('public'), 'The public group exists');
   ok(!$irods->group_exists('no_such_group'), 'An absent group does not exist');
 }
 


### PR DESCRIPTION
Remove the combination of 4.2.11 clients with a 4.2.7 server

Add the combination of 4.2.7 clients with a 4.2.7 server Add the combination of 4.3-nightly clients with a 4.3-nightly server