### PR TITLE
fix(replicate): accept physical_path field from baton >= 6.1.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
-Unreleased 
+Unreleased
+ - Accept the physical_path field added to replicate listings by
+   baton >= 6.1.0; older baton versions that do not report it are
+   unaffected
 
 Release 3.28.2 (2026-04-16)
  - Remove workaround for IPC::Run caching bug fixed in 20260322.0

--- a/lib/WTSI/NPG/iRODS/Replicate.pm
+++ b/lib/WTSI/NPG/iRODS/Replicate.pm
@@ -36,6 +36,14 @@ has 'valid' =>
    required      => 1,
    documentation => 'The state of the replicate as reported by iRODS.');
 
+has 'physical_path' =>
+  (is            => 'ro',
+   isa           => 'Maybe[Str]',
+   required      => 0,
+   documentation => 'The physical path of the replicate on the resource ' .
+                     'server filesystem. Reported by baton >= 6.1.0 only; ' .
+                     'undefined when using an older baton version.');
+
 sub is_valid {
   my ($self) = @_;
 
@@ -58,7 +66,9 @@ characteristics of an iRODS data object;
 =head1 DESCRIPTION
 
 Describes a single replicate of an iRODS data object in terms of its
-replicate number, checksum, resource, location and status.
+replicate number, checksum, resource, location, status and (where
+reported by the baton client, version >= 6.1.0) its physical path on
+the resource server filesystem.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Assuming it is ok to have it as optional, so we maintain backwards compat with previous batons.